### PR TITLE
Make ReactFireMixin browserifyable

### DIFF
--- a/build/footer
+++ b/build/footer
@@ -1,7 +1,2 @@
   return ReactFireMixin;
-})();
-
-// Export ReactFireMixin if this is being run in node
-if (typeof module !== "undefined" && typeof process !== "undefined") {
-  module.exports = ReactFireMixin;
-}
+}));

--- a/build/header
+++ b/build/header
@@ -8,5 +8,18 @@
  * License: MIT
  */
 
-var ReactFireMixin = (function() {
+;(function (root, factory) {
+  if (typeof exports === "object") {
+    // CommonJS
+    module.exports = factory();
+  } else if (typeof define === "function" && define.amd) {
+    // AMD
+    define([], function() {
+      return (root.ReactFireMixin = factory());
+    });
+  } else {
+    // Global Variables
+    root.ReactFireMixin = factory();
+  }
+}(this, function() {
   "use strict";


### PR DESCRIPTION
The current build footer export won't export anything when ReactFireMixin is browserified.

Replacing the build header & footer with standard UMD boilerplate will fix this and also make it usable for AMD users.
