### PR TITLE
Suggetion: Add bind methods with "foreign keys"

### DIFF
--- a/src/reactfire.js
+++ b/src/reactfire.js
@@ -31,6 +31,31 @@ var ReactFireMixin = {
     this._bind(firebaseRef, bindVar, false);
   },
 
+  /* Uses the firebaseRef to create specific bindings to foreignRef */
+  bindForeignAsObject: function(firebaseRef, foreignRef, bindVar) {
+    this.firebaseRefs[bindVar] = firebaseRef.ref();
+
+    this.firebaseListeners[bindVar + "/add"] = firebaseRef.on("child_added", function(snap) {
+      this.firebaseRefs[bindVar + "/" + snap.name()] = foreignRef.child(snap.name());
+
+      this.firebaseListeners[bindVar + "/" + snap.name()] = this.firebaseRefs[bindVar + "/" + snap.name()].on("value", function(snap) {
+        var newState = {};
+        newState[bindVar] = this.state && this.state[bindVar] ? this.state[bindVar] : {};
+        newState[bindVar][snap.name()] = snap.val();
+        this.setState(newState);
+      }.bind(this));
+    }.bind(this));
+
+    this.firebaseListeners[bindVar + "/remove"] = firebaseRef.on("child_removed", function(snap) {
+      this.firebaseRefs[bindVar + "/" + snap.name()].off("value", this.firebaseListeners[bindVar + "/" + snap.name()]);
+
+      var newState = {};
+      newState[bindVar] = this.state && this.state[bindVar] ? this.state[bindVar] : {};
+      delete newState[bindVar][snap.name()];
+      this.setState(newState);
+    }.bind(this));
+  },
+
   /* Creates a binding between Firebase and the inputted bind variable as either an array or object */
   _bind: function(firebaseRef, bindVar, bindAsArray) {
     this._validateBindVar(bindVar);


### PR DESCRIPTION
Hi!

I love the simplicity of reactfire. In fact I've tried to use react with firebase as a replacement for the whole react flux thing a couple of times, but I end up lacking this one feature.

A very normal pattern for firebase apps is flattening the structure and creating per user indexes of what data to sync. That doesn't map very well to reactfire.

I would like to see something like this:

this.bindForeignAsObject(refToMyListOfObjects, refToAllObjects, 'myObjects')

e.g.:

var friendsRef = ref.child('users').child(uid).child('friends')
var usersRef = ref.child('users')
this.bindForeignAsObject(friendsRef, usersRef, 'friends')

and then have state.myObjects have all objects in refToAllObjects that are also in refToMyListOfObjects synced. I've attached a proof of concept. Would be happy to make it prettier if it makes sense.
