### PR TITLE
Changed main in package.json and bower.json to unminified file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "firebase",
     "realtime"
   ],
-  "main": "dist/reactfire.min.js",
+  "main": "dist/reactfire.js",
   "ignore": [
     "**/.*",
     "src",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "realtime",
     "react-component"
   ],
-  "main": "dist/reactfire.min.js",
+  "main": "dist/reactfire.js",
   "files": [
     "dist/**",
     "LICENSE",


### PR DESCRIPTION
@mimming - Please review and merge. After [much discussion and debate on this topic over on the AngularFire repo](https://github.com/firebase/angularfire/issues/436), I now believe we should be including the unminified files as `main` in the `package.json` and `bower.json`.
