### PR TITLE
Added a _refName property when converting Firebase object to an array

### DIFF
--- a/src/reactfire.js
+++ b/src/reactfire.js
@@ -125,6 +125,7 @@ var ReactFireMixin = {
       else if (typeof(obj) === "object") {
         for (var key in obj) {
           if (obj.hasOwnProperty(key)) {
+            obj[key]['_refName'] = key;
             out.push(obj[key]);
           }
         }


### PR DESCRIPTION
Hi, 

I was playing with this awesome ReactFire library, and I ran into this issue:

I used the `bindAsArray` method to bind a list of items to a Firebase ref. And then when rendering that list I needed to have a `key` property for each item in it. I saw some people using the index variable of a loop to create this `key` property, but according to React's documentation (http://facebook.github.io/react/docs/multiple-components.html#dynamic-children) I think that's not the proper way of doing it.

So I thought it'd be nice to get the unique ref name of each item in the bound array (maybe something named `_refName` to avoid potential conflicts) to be able to use a simple `key={item._refName}`.

Cheers!
