### PR TITLE
Make sure useUser works predictably in AuthCheck

### DIFF
--- a/reactfire/auth/auth.test.tsx
+++ b/reactfire/auth/auth.test.tsx
@@ -1,18 +1,41 @@
-import { cleanup, render } from '@testing-library/react';
-import { auth } from 'firebase/app';
+import { cleanup, render, waitForElement, wait } from '@testing-library/react';
+import { auth, User } from 'firebase/app';
 import '@testing-library/jest-dom/extend-expect';
 import * as React from 'react';
-import { AuthCheck } from '.';
+import { AuthCheck, useUser } from '.';
 import { FirebaseAppProvider } from '..';
+import { Observable, Observer } from 'rxjs';
+import { act } from 'react-dom/test-utils';
 
-const mockAuth = jest.fn(() => {
-  return {
-    onIdTokenChanged: jest.fn()
-  };
-});
+class MockAuth {
+  user: Object | null;
+  subscriber: Observer<any> | null;
+  constructor() {
+    this.user = null;
+    this.subscriber = null;
+  }
+
+  notifySubscriber() {
+    if (this.subscriber) {
+      this.subscriber.next(this.user);
+    }
+  }
+
+  onIdTokenChanged(s) {
+    this.subscriber = s;
+    this.notifySubscriber();
+  }
+
+  updateUser(u: Object) {
+    this.user = u;
+    this.notifySubscriber();
+  }
+}
+
+const mockAuth = new MockAuth();
 
 const mockFirebase = {
-  auth: mockAuth
+  auth: () => mockAuth
 };
 
 const Provider = ({ children }) => (
@@ -21,22 +44,29 @@ const Provider = ({ children }) => (
   </FirebaseAppProvider>
 );
 
+const Component = ({ children }) => (
+  <Provider>
+    <React.Suspense fallback={'loading'}>
+      <AuthCheck fallback={<h1 data-testid="signed-out">not signed in</h1>}>
+        {children || <h1 data-testid="signed-in">signed in</h1>}
+      </AuthCheck>
+    </React.Suspense>
+  </Provider>
+);
+
 describe('AuthCheck', () => {
+  beforeEach(() => {
+    // clear the signed in user
+    mockFirebase.auth().updateUser(null);
+  });
+
   afterEach(() => {
     cleanup();
     jest.clearAllMocks();
   });
 
   it('can find firebase Auth from Context', () => {
-    expect(() =>
-      render(
-        <Provider>
-          <React.Suspense fallback={'loading'}>
-            <AuthCheck fallback={'loading'}>{'children'}</AuthCheck>
-          </React.Suspense>
-        </Provider>
-      )
-    ).not.toThrow();
+    expect(() => render(<Component />)).not.toThrow();
   });
 
   it('can use firebase Auth from props', () => {
@@ -54,14 +84,62 @@ describe('AuthCheck', () => {
     ).not.toThrow();
   });
 
-  test.todo('renders the fallback if a user is not signed in');
+  it('renders the fallback if a user is not signed in', async () => {
+    const { getByTestId } = render(<Component />);
 
-  test.todo('renders children if a user is logged in');
+    await wait(() => expect(getByTestId('signed-out')).toBeInTheDocument());
+
+    act(() => mockFirebase.auth().updateUser({ uid: 'testuser' }));
+
+    await wait(() => expect(getByTestId('signed-in')).toBeInTheDocument());
+  });
+
+  it('renders children if a user is logged in', async () => {
+    mockFirebase.auth().updateUser({ uid: 'testuser' });
+    const { getByTestId } = render(<Component />);
+
+    await wait(() => expect(getByTestId('signed-in')).toBeInTheDocument());
+  });
+
+  it('can switch between logged in and logged out', async () => {
+    const { getByTestId } = render(<Component />);
+
+    await wait(() => expect(getByTestId('signed-out')).toBeInTheDocument());
+
+    act(() => mockFirebase.auth().updateUser({ uid: 'testuser' }));
+
+    await wait(() => expect(getByTestId('signed-in')).toBeInTheDocument());
+
+    act(() => mockFirebase.auth().updateUser(null));
+
+    await wait(() => expect(getByTestId('signed-out')).toBeInTheDocument());
+  });
 
   test.todo('checks requiredClaims');
 });
 
 describe('useUser', () => {
+  it('always returns a user if inside an <AuthCheck> component', () => {
+    const UserDetails = () => {
+      const user = useUser();
+
+      expect(user).not.toBeNull();
+      expect(user).toBeDefined();
+
+      return <h1>Hello</h1>;
+    };
+
+    render(
+      <>
+        <Component>
+          <UserDetails />
+        </Component>
+      </>
+    );
+
+    act(() => mockFirebase.auth().updateUser({ uid: 'testuser' }));
+  });
+
   test.todo('can find firebase.auth() from Context');
 
   test.todo('throws an error if firebase.auth() is not available');

--- a/reactfire/package.json
+++ b/reactfire/package.json
@@ -38,7 +38,7 @@
     "@firebase/testing": "^0.11.4",
     "@testing-library/jest-dom": "^4.1.1",
     "@testing-library/react": "^9.3.0",
-    "@testing-library/react-hooks": "^2.0.3",
+    "@testing-library/react-hooks": "^3.1.0",
     "@types/jest": "^24.0.11",
     "babel-jest": "^24.7.1",
     "firebase-tools": "^7.1.0",

--- a/reactfire/useObservable/index.ts
+++ b/reactfire/useObservable/index.ts
@@ -39,6 +39,11 @@ export function useObservable(
   React.useEffect(() => {
     const subscription = observable$.pipe(startWith(initialValue)).subscribe(
       newVal => {
+        // update the value in requestCache
+        const request = requestCache.getRequest(observable$, observableId);
+        request.setValue(newVal);
+
+        // update state
         setValue(newVal);
       },
       error => {

--- a/reactfire/useObservable/index.ts
+++ b/reactfire/useObservable/index.ts
@@ -31,8 +31,12 @@ export function useObservable(
   observableId: string,
   startWithValue?: any
 ) {
+  const request = requestCache.getRequest(observable$, observableId);
+
   const initialValue =
-    startWithValue || suspendUntilFirst(observable$, observableId);
+    request.value ||
+    startWithValue ||
+    suspendUntilFirst(observable$, observableId);
 
   const [latestValue, setValue] = React.useState(initialValue);
 
@@ -40,7 +44,6 @@ export function useObservable(
     const subscription = observable$.pipe(startWith(initialValue)).subscribe(
       newVal => {
         // update the value in requestCache
-        const request = requestCache.getRequest(observable$, observableId);
         request.setValue(newVal);
 
         // update state

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,10 +1885,10 @@
     pretty-format "^24.0.0"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-2.0.3.tgz#305a6c76facb5fa1d185792b9eb11b1ca1b63fb7"
-  integrity sha512-adm+7b1gcysGka8VuYq/ObBrIBJTT9QmCEIqPpuxozWFfVDgxSbzBGc44ia/WYLGVt2dqFIOc6/DmAmu/pa0gQ==
+"@testing-library/react-hooks@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.1.0.tgz#f186c4f3b32db153d30d646faacb043ef4089807"
+  integrity sha512-mwFDHXCQiyr0tQkYU4VkcwlCzR5YQ5k1/TCrL3hPslCM5MvS6pBhbl2z4UnCMV4DOyiUUXIvoMAf5kHT/hibTg==
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@types/testing-library__react-hooks" "^2.0.0"


### PR DESCRIPTION
fixes #155 

Due to a bug in the internals of `useObservable`, sometimes useUser would emit `null` when it was the child of an `<AuthCheck>` component, which should be impossible.

To fix this, I created a test (called _always returns a user if inside an <AuthCheck> component_) and verified that it failed in the existing ReactFire. Then, I fixed `userObservable` and verified that the test passed.