### PR TITLE
update return type for AuthCheck and SuspenseWithPerf to JSX.Element

### DIFF
--- a/reactfire/auth/index.tsx
+++ b/reactfire/auth/index.tsx
@@ -82,8 +82,8 @@ export function AuthCheck({
   });
 
   if (!user) {
-    return <>fallback</>;
+    return <>{fallback}</>;
   } else {
-    return <>children</>;
+    return <>{children}</>;
   }
 }

--- a/reactfire/auth/index.tsx
+++ b/reactfire/auth/index.tsx
@@ -54,7 +54,7 @@ export function AuthCheck({
   fallback,
   children,
   requiredClaims
-}: AuthCheckProps): React.ReactNode {
+}: AuthCheckProps): JSX.Element {
   const user = useUser<User>(auth);
 
   React.useLayoutEffect(() => {

--- a/reactfire/auth/index.tsx
+++ b/reactfire/auth/index.tsx
@@ -82,8 +82,8 @@ export function AuthCheck({
   });
 
   if (!user) {
-    return fallback;
+    return <>fallback</>;
   } else {
-    return children;
+    return <>children</>;
   }
 }

--- a/reactfire/performance/index.tsx
+++ b/reactfire/performance/index.tsx
@@ -33,7 +33,7 @@ export function SuspenseWithPerf({
   traceId,
   fallback,
   firePerf
-}: SuspensePerfProps) {
+}: SuspensePerfProps): JSX.Element {
   firePerf = firePerf || getPerfFromContext();
 
   const Fallback = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11112,6 +11112,14 @@ react@^16.8.6:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
+reactfire@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/reactfire/-/reactfire-2.0.0.tgz#492730ce51ee4c1b2fd5310960261090a294d4b8"
+  integrity sha512-e0IInm/0DlQDCxiIrim6Ox3x+YrPEwXBWXDzSz2WUDUz+EYOTfOSr8WpP4PKcYjLzUJBtSDHXoCqJ2boWRiMow==
+  dependencies:
+    rxfire "^3.6.3"
+    rxjs "^6.4.0"
+
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11112,14 +11112,6 @@ react@^16.8.6:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
-reactfire@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/reactfire/-/reactfire-2.0.0.tgz#492730ce51ee4c1b2fd5310960261090a294d4b8"
-  integrity sha512-e0IInm/0DlQDCxiIrim6Ox3x+YrPEwXBWXDzSz2WUDUz+EYOTfOSr8WpP4PKcYjLzUJBtSDHXoCqJ2boWRiMow==
-  dependencies:
-    rxfire "^3.6.3"
-    rxjs "^6.4.0"
-
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"


### PR DESCRIPTION
Update return type from React.ReactNode to JSX.Element

Resolves https://github.com/FirebaseExtended/reactfire/issues/138

