### PR TITLE
[New Stuff] Auth Custom Claims

### DIFF
--- a/reactfire/auth/index.tsx
+++ b/reactfire/auth/index.tsx
@@ -2,6 +2,7 @@ import { auth, User } from 'firebase/app';
 import * as React from 'react';
 import { user } from 'rxfire/auth';
 import { useObservable, useFirebaseApp, ReactFireOptions } from '..';
+import { from } from 'rxjs';
 
 function getAuthFromContext(): auth.Auth {
   const firebaseApp = useFirebaseApp();
@@ -42,11 +43,48 @@ export function useUser<T = unknown>(
   );
 }
 
+export function useIdTokenResult(user: User, forceRefresh: boolean = false) {
+  if (!user) {
+    throw new Error('you must provide a user');
+  }
+
+  const idToken$ = from(user.getIdTokenResult(forceRefresh));
+
+  return useObservable(idToken$, `${user.uid}-claims`);
+}
+
 export interface AuthCheckProps {
   auth?: auth.Auth;
   fallback: React.ReactNode;
   children: React.ReactNode;
   requiredClaims?: Object;
+}
+
+export interface ClaimsCheckProps {
+  user: User;
+  fallback: React.ReactNode;
+  children: React.ReactNode;
+  requiredClaims?: Object;
+}
+
+export function ClaimsCheck({ user, fallback, children, requiredClaims }) {
+  const { claims } = useIdTokenResult(user, false);
+  const missingClaims = {};
+
+  Object.keys(requiredClaims).forEach(claim => {
+    if (requiredClaims[claim] !== claims[claim]) {
+      missingClaims[claim] = {
+        expected: requiredClaims[claim],
+        actual: claims[claim]
+      };
+    }
+  });
+
+  if (Object.keys(missingClaims).length === 0) {
+    return children;
+  } else {
+    return fallback;
+  }
 }
 
 export function AuthCheck({
@@ -57,33 +95,19 @@ export function AuthCheck({
 }: AuthCheckProps): React.ReactNode {
   const user = useUser<User>(auth);
 
-  React.useLayoutEffect(() => {
-    // TODO(jeff) see if this actually works
-    if (requiredClaims) {
-      throw user.getIdTokenResult().then(idTokenResult => {
-        const { claims } = idTokenResult;
-        const missingClaims = {};
-        Object.keys(requiredClaims).forEach(claim => {
-          if (requiredClaims[claim] !== claims[claim]) {
-            missingClaims[claim] = {
-              expected: requiredClaims[claim],
-              actual: claims[claim]
-            };
-          }
-        });
-
-        if (Object.keys(missingClaims).length > 0) {
-          throw new Error(
-            `Mismatched Claims: ${JSON.stringify(missingClaims)}`
-          );
-        }
-      });
-    }
-  });
-
-  if (!user) {
-    return fallback;
+  if (user) {
+    return requiredClaims ? (
+      <ClaimsCheck
+        user={user}
+        fallback={fallback}
+        requiredClaims={requiredClaims}
+      >
+        {children}
+      </ClaimsCheck>
+    ) : (
+      children
+    );
   } else {
-    return children;
+    return fallback;
   }
 }


### PR DESCRIPTION
The `AuthCheck` component had a `requiredClaims` prop, but it didn't actually work. This PR fixes that, and introduces a new Hook and Component along the way:

## `useIdTokenResult`

Wraps the Firebase JS SDK's `user.getIdTokenResult`. If you want to check custom claims, you can do this:

```jsx
const { claims } = useIdTokenResult(user, false);
```

To force a refresh, pass `true` as the second argument:

```jsx
const { claims } = useIdTokenResult(user, true);
```

## `ClaimsCheck`

Like `AuthCheck`, but only checks claims

```jsx
<ClaimsCheck
  user={user}
  fallback={<h1>Required Claims Not Met</h1>}
  requiredClaims={{admin: true}}
>
  <h1>You Have The Correct Claims</h1>
</ClaimsCheck>
```

## `AuthCheck`'s requiredClaims

If the `requiredClaims` prop is set, `AuthCheck` only renders children if a user is logged in AND they meet their required claims.

```jsx
<AuthCheck
  fallback={<h1>Not Logged In or Required Claims Not Met</h1>}
  requiredClaims={{ admin: true }}
>
  <h1>You Are Logged In and Have The Correct Claims</h1>
</AuthCheck>;
```

fixes #161 