### PR TITLE
Clarify versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ Status: Alpha
 
 ```bash
 # npm
-npm install reactfire
+npm install reactfire@next
 # yarn
-yarn add reactfire
+yarn add reactfire@next
 ```
+
+If you like living life on the edge, use `reactfire@canary`.
 
 ## Example use
 


### PR DESCRIPTION
### Description

Clarifying that to get 2.0, which the code examples refer to, requires installing `reactfire@next` or `reactfire@canary`. As it is, `yarn add reactfire` gives you 1.0.0 which results in a lot of errors when using the code examples and no real hint as to why.