### PR TITLE
Improve IDs passed to useObservable

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -104,10 +104,10 @@ _Throws a Promise by default_
 
 #### Parameters
 
-| Parameter   | Type                                                                                                          | Description                                                                  |
-| ----------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| ref         | [`CollectionReference`](https://firebase.google.com/docs/reference/js/firebase.firestore.CollectionReference) | A reference to the collection you want to listen to                          |
-| options _?_ | ReactFireOptions                                                                                              | Options. This hook will not throw a Promise if you provide `startWithValue`. |
+| Parameter   | Type                                                                              | Description                                                                  |
+| ----------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| ref         | [`Query`](https://firebase.google.com/docs/reference/js/firebase.firestore.Query) | A query for the collection you want to listen to                             |
+| options _?_ | ReactFireOptions                                                                  | Options. This hook will not throw a Promise if you provide `startWithValue`. |
 
 #### Returns
 

--- a/reactfire/auth/index.tsx
+++ b/reactfire/auth/index.tsx
@@ -37,7 +37,7 @@ export function useUser<T = unknown>(
 
   return useObservable(
     user(auth),
-    'user',
+    'auth: user',
     options ? options.startWithValue : undefined
   );
 }

--- a/reactfire/database/database.test.tsx
+++ b/reactfire/database/database.test.tsx
@@ -30,7 +30,7 @@ describe('Realtime Database (RTDB)', () => {
 
   test('sanity check - emulator is running', () => {
     // IF THIS TEST FAILS, MAKE SURE YOU'RE RUNNING THESE TESTS BY DOING:
-    //
+    // yarn test
 
     return app
       .database()

--- a/reactfire/database/database.test.tsx
+++ b/reactfire/database/database.test.tsx
@@ -1,11 +1,140 @@
 import '@testing-library/jest-dom/extend-expect';
+import { render, waitForElement, cleanup, act } from '@testing-library/react';
+import * as React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import * as firebase from '@firebase/testing';
+import { useDatabaseObject, useDatabaseList, FirebaseAppProvider } from '..';
+import { database } from 'firebase/app';
+import { QueryChange } from 'rxfire/database/dist/database';
 
 describe('Realtime Database (RTDB)', () => {
+  let app: import('firebase').app.App;
+
+  beforeAll(async () => {
+    app = firebase.initializeTestApp({
+      projectId: '12345',
+      databaseName: 'my-database',
+      auth: { uid: 'alice' }
+    }) as import('firebase').app.App;
+  });
+
+  afterEach(async () => {
+    cleanup();
+
+    // clear out the database
+    app
+      .database()
+      .ref()
+      .set(null);
+  });
+
+  test('sanity check - emulator is running', () => {
+    // IF THIS TEST FAILS, MAKE SURE YOU'RE RUNNING THESE TESTS BY DOING:
+    //
+
+    return app
+      .database()
+      .ref('hello')
+      .set({ a: 'world' });
+  });
+
   describe('useDatabaseObject', () => {
-    test.todo("returns the same value as ref.on('value')");
+    it('can get an object [TEST REQUIRES EMULATOR]', async () => {
+      const mockData = { a: 'hello' };
+
+      const ref = app.database().ref('hello');
+
+      await ref.set(mockData);
+
+      const ReadObject = () => {
+        const { snapshot } = useDatabaseObject(ref);
+
+        return <h1 data-testid="readSuccess">{snapshot.val().a}</h1>;
+      };
+
+      const { getByTestId } = render(
+        <FirebaseAppProvider firebase={app}>
+          <React.Suspense fallback={<h1 data-testid="fallback">Fallback</h1>}>
+            <ReadObject />
+          </React.Suspense>
+        </FirebaseAppProvider>
+      );
+
+      await waitForElement(() => getByTestId('readSuccess'));
+
+      expect(getByTestId('readSuccess')).toContainHTML(mockData.a);
+    });
   });
 
   describe('useDatabaseList', () => {
-    test.todo("returns the same value as ref.on('value')");
+    it('can get a list [TEST REQUIRES EMULATOR]', async () => {
+      const mockData1 = { a: 'hello' };
+      const mockData2 = { a: 'goodbye' };
+
+      const ref = app.database().ref('myList');
+
+      await act(() => ref.push(mockData1));
+      await act(() => ref.push(mockData2));
+
+      const ReadList = () => {
+        const changes = useDatabaseList(ref) as QueryChange[];
+
+        return (
+          <ul data-testid="readSuccess">
+            {changes.map(({ snapshot }) => (
+              <li key={snapshot.key} data-testid="listItem">
+                {snapshot.val().a}
+              </li>
+            ))}
+          </ul>
+        );
+      };
+
+      const { getAllByTestId } = render(
+        <FirebaseAppProvider firebase={app}>
+          <React.Suspense fallback={<h1 data-testid="fallback">Fallback</h1>}>
+            <ReadList />
+          </React.Suspense>
+        </FirebaseAppProvider>
+      );
+
+      await waitForElement(() => getAllByTestId('listItem'));
+
+      expect(getAllByTestId('listItem').length).toEqual(2);
+    });
+
+    it('Returns different data for different queries on the same path [TEST REQUIRES EMULATOR]', async () => {
+      const mockData1 = { a: 'hello' };
+      const mockData2 = { a: 'goodbye' };
+
+      const ref = app.database().ref('items');
+      const filteredRef = ref.orderByChild('a').equalTo('hello');
+
+      await act(() => ref.push(mockData1));
+      await act(() => ref.push(mockData2));
+
+      const ReadFirestoreCollection = () => {
+        const list = useDatabaseList(ref) as QueryChange[];
+        const filteredList = useDatabaseList(filteredRef) as QueryChange[];
+
+        // filteredList's length should be 1 since we only added one value that matches its query
+        expect(filteredList.length).toEqual(1);
+
+        // the full list should be bigger than the filtered list
+        expect(list.length).toBeGreaterThan(filteredList.length);
+
+        return <h1 data-testid="rendered">Hello</h1>;
+      };
+
+      const { getByTestId } = render(
+        <FirebaseAppProvider firebase={app}>
+          <React.Suspense fallback={<h1 data-testid="fallback">Fallback</h1>}>
+            <ReadFirestoreCollection />
+          </React.Suspense>
+        </FirebaseAppProvider>
+      );
+
+      await waitForElement(() => getByTestId('rendered'));
+    });
   });
 });

--- a/reactfire/database/index.tsx
+++ b/reactfire/database/index.tsx
@@ -14,9 +14,16 @@ export function useDatabaseObject<T = unknown>(
 ): QueryChange | T {
   return useObservable(
     object(ref),
-    ref.toString(),
+    `RTDB: ${ref.toString()}`,
     options ? options.startWithValue : undefined
   );
+}
+
+// Realtime Database has an undocumented method
+// that helps us build a unique ID for the query
+// https://github.com/firebase/firebase-js-sdk/blob/aca99669dd8ed096f189578c47a56a8644ac62e6/packages/database/src/api/Query.ts#L601
+interface _QueryWithId extends database.Query {
+  queryIdentifier(): string;
 }
 
 /**
@@ -29,9 +36,11 @@ export function useDatabaseList<T = { [key: string]: unknown }>(
   ref: database.Reference | database.Query,
   options?: ReactFireOptions<T[]>
 ): QueryChange[] | T[] {
+  const hash = `RTDB: ${ref.toString()}|${(ref as _QueryWithId).queryIdentifier()}`;
+
   return useObservable(
     list(ref),
-    ref.toString(),
+    hash,
     options ? options.startWithValue : undefined
   );
 }

--- a/reactfire/firestore/firestore.test.tsx
+++ b/reactfire/firestore/firestore.test.tsx
@@ -1,5 +1,4 @@
-import { renderHook, act } from '@testing-library/react-hooks';
-import { render, waitForElement, cleanup } from '@testing-library/react';
+import { render, waitForElement, cleanup, act } from '@testing-library/react';
 
 import * as React from 'react';
 import '@testing-library/jest-dom/extend-expect';
@@ -105,9 +104,6 @@ describe('Firestore', () => {
     });
   });
 
-  // THIS TEST CAUSES A REACT `act` WARNING
-  // IT WILL BE FIXED IN REACT 16.9
-  // More info here: https://github.com/testing-library/react-testing-library/issues/281
   describe('useFirestoreCollection', () => {
     it('can get a Firestore collection [TEST REQUIRES EMULATOR]', async () => {
       const mockData1 = { a: 'hello' };
@@ -115,8 +111,8 @@ describe('Firestore', () => {
 
       const ref = app.firestore().collection('testCollection');
 
-      await ref.add(mockData1);
-      await ref.add(mockData2);
+      await act(() => ref.add(mockData1));
+      await act(() => ref.add(mockData2));
 
       const ReadFirestoreCollection = () => {
         const collection = useFirestoreCollection(ref);
@@ -143,11 +139,45 @@ describe('Firestore', () => {
 
       expect(getAllByTestId('listItem').length).toEqual(2);
     });
+
+    it('Returns different data for different queries on the same path [TEST REQUIRES EMULATOR]', async () => {
+      const mockData1 = { a: 'hello' };
+      const mockData2 = { a: 'goodbye' };
+
+      const ref = app.firestore().collection('testCollection');
+      const filteredRef = ref.where('a', '==', 'hello');
+
+      await act(() => ref.add(mockData1));
+      await act(() => ref.add(mockData2));
+
+      const ReadFirestoreCollection = () => {
+        const list = (useFirestoreCollection(ref) as firestore.QuerySnapshot)
+          .docs;
+        const filteredList = (useFirestoreCollection(
+          filteredRef
+        ) as firestore.QuerySnapshot).docs;
+
+        // filteredList's length should be 1 since we only added one value that matches its query
+        expect(filteredList.length).toEqual(1);
+
+        // the full list should be bigger than the filtered list
+        expect(list.length).toBeGreaterThan(filteredList.length);
+
+        return <h1 data-testid="rendered">Hello</h1>;
+      };
+
+      const { getByTestId } = render(
+        <FirebaseAppProvider firebase={app}>
+          <React.Suspense fallback={<h1 data-testid="fallback">Fallback</h1>}>
+            <ReadFirestoreCollection />
+          </React.Suspense>
+        </FirebaseAppProvider>
+      );
+
+      await waitForElement(() => getByTestId('rendered'));
+    });
   });
 
-  // THIS TEST CAUSES A REACT `act` WARNING
-  // IT WILL BE FIXED IN REACT 16.9
-  // More info here: https://github.com/testing-library/react-testing-library/issues/281
   describe('useFirestoreCollectionData', () => {
     it('can get a Firestore collection [TEST REQUIRES EMULATOR]', async () => {
       const mockData1 = { a: 'hello' };
@@ -155,8 +185,8 @@ describe('Firestore', () => {
 
       const ref = app.firestore().collection('testCollection');
 
-      await ref.add(mockData1);
-      await ref.add(mockData2);
+      await act(() => ref.add(mockData1));
+      await act(() => ref.add(mockData2));
 
       const ReadFirestoreCollection = () => {
         const list = useFirestoreCollectionData<any>(ref, { idField: 'id' });
@@ -182,6 +212,42 @@ describe('Firestore', () => {
       await waitForElement(() => getAllByTestId('listItem'));
 
       expect(getAllByTestId('listItem').length).toEqual(2);
+    });
+
+    it('Returns different data for different queries on the same path [TEST REQUIRES EMULATOR]', async () => {
+      const mockData1 = { a: 'hello' };
+      const mockData2 = { a: 'goodbye' };
+
+      const ref = app.firestore().collection('testCollection');
+      const filteredRef = ref.where('a', '==', 'hello');
+
+      await act(() => ref.add(mockData1));
+      await act(() => ref.add(mockData2));
+
+      const ReadFirestoreCollection = () => {
+        const list = useFirestoreCollectionData<any>(ref, { idField: 'id' });
+        const filteredList = useFirestoreCollectionData<any>(filteredRef, {
+          idField: 'id'
+        });
+
+        // filteredList's length should be 1 since we only added one value that matches its query
+        expect(filteredList.length).toEqual(1);
+
+        // the full list should be bigger than the filtered list
+        expect(list.length).toBeGreaterThan(filteredList.length);
+
+        return <h1 data-testid="rendered">Hello</h1>;
+      };
+
+      const { getByTestId } = render(
+        <FirebaseAppProvider firebase={app}>
+          <React.Suspense fallback={<h1 data-testid="fallback">Fallback</h1>}>
+            <ReadFirestoreCollection />
+          </React.Suspense>
+        </FirebaseAppProvider>
+      );
+
+      await waitForElement(() => getByTestId('rendered'));
     });
   });
 });

--- a/reactfire/firestore/firestore.test.tsx
+++ b/reactfire/firestore/firestore.test.tsx
@@ -31,7 +31,7 @@ describe('Firestore', () => {
 
   test('sanity check - emulator is running', () => {
     // IF THIS TEST FAILS, MAKE SURE YOU'RE RUNNING THESE TESTS BY DOING:
-    //
+    // yarn test
 
     return app
       .firestore()

--- a/reactfire/package.json
+++ b/reactfire/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "build-dev": "tsc --watch",
     "test-dev": "jest --verbose --watch",
-    "emulator": "firebase emulators:start --only firestore",
-    "test": "firebase emulators:exec --only firestore \"jest --no-cache --verbose --detectOpenHandles --forceExit\"",
+    "emulators": "firebase emulators:start --only firestore,database",
+    "test": "firebase emulators:exec --only firestore,database \"jest --no-cache --verbose --detectOpenHandles --forceExit\"",
     "copy-package-json": "cp package.pub.json pub/reactfire/package.json",
     "watch": "yarn build && tsc --watch",
     "build": "rm -rf pub && tsc && yarn copy-package-json && cp ../README.md pub/reactfire/README.md && cp ../LICENSE pub/reactfire/LICENSE"

--- a/reactfire/storage/index.tsx
+++ b/reactfire/storage/index.tsx
@@ -38,7 +38,7 @@ export function useStorageTask<T = unknown>(
 ): storage.UploadTaskSnapshot | T {
   return useObservable(
     _fromTask(task),
-    'upload' + ref.toString(),
+    'storage upload: ' + ref.toString(),
     options ? options.startWithValue : undefined
   );
 }
@@ -55,7 +55,7 @@ export function useStorageDownloadURL<T = string>(
 ): string | T {
   return useObservable(
     getDownloadURL(ref),
-    'download' + ref.toString(),
+    'storage download:' + ref.toString(),
     options ? options.startWithValue : undefined
   );
 }

--- a/reactfire/useObservable/index.ts
+++ b/reactfire/useObservable/index.ts
@@ -31,6 +31,10 @@ export function useObservable(
   observableId: string,
   startWithValue?: any
 ) {
+  if (!observableId) {
+    throw new Error('cannot call useObservable without an observableId');
+  }
+
   const request = requestCache.getRequest(observable$, observableId);
 
   const initialValue =

--- a/reactfire/useObservable/useObservable.test.tsx
+++ b/reactfire/useObservable/useObservable.test.tsx
@@ -18,6 +18,16 @@ describe('useObservable', () => {
     }
   });
 
+  it('throws an error if no observableId is provided', () => {
+    const observable$: Subject<any> = new Subject();
+
+    try {
+      useObservable(observable$, undefined);
+    } catch (thingThatWasThrown) {
+      expect(thingThatWasThrown).toBeInstanceOf(Error);
+    }
+  });
+
   it('can return a startval and then the observable once it is ready', () => {
     const startVal = 'howdy';
     const observableVal = "y'all";


### PR DESCRIPTION
As pointed out in #166, if two queries on the same path had different filters/sorts, ReactFire may have used one query instead of treating them as two different queries because the `observableId` wasn't specific enough. The PR fixes that issue, adds more descriptive `observableId`s overall, and adds tests to make sure we don't reintroduce this behavior in the future. 