### PR TITLE
feat(auth): set auth.currentUser as its startWithValue in useUser - #158

### DIFF
--- a/reactfire/auth/index.tsx
+++ b/reactfire/auth/index.tsx
@@ -36,11 +36,17 @@ export function useUser<T = unknown>(
 ): User | T {
   auth = auth || getAuthFromContext();
 
-  return useObservable(
-    user(auth),
-    'auth: user',
-    options ? options.startWithValue : auth.currentUser
-  );
+  let currentUser = undefined;
+
+  if (options && options.startWithValue !== undefined) {
+    currentUser = options.startWithValue;
+  } else if (auth.currentUser) {
+    // if auth.currentUser is undefined or null, we won't use it
+    // because null can mean "not signed in" OR "still loading"
+    currentUser = auth.currentUser;
+  }
+
+  return useObservable(user(auth), 'auth: user', currentUser);
 }
 
 export function useIdTokenResult(user: User, forceRefresh: boolean = false) {

--- a/reactfire/auth/index.tsx
+++ b/reactfire/auth/index.tsx
@@ -38,7 +38,7 @@ export function useUser<T = unknown>(
   return useObservable(
     user(auth),
     'user',
-    options ? options.startWithValue : undefined
+    options ? options.startWithValue : auth.currentUser
   );
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
* set [`auth.currentUser`](https://firebase.google.com/docs/reference/js/firebase.auth.Auth.html#currentuser) as `startWithValue` in `useUser` as mentioned by #158 and [this comment](https://github.com/FirebaseExtended/reactfire/issues/155#issuecomment-542846892)

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
