### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "workspaces": [
     "reactfire",
     "reactfire/pub/reactfire",
-    "sample-simple",
-    "sample-complex"
+    "sample"
   ],
   "devDependencies": {
     "husky": "^3.0.8",


### PR DESCRIPTION
When I deleted the sample-complex directory and renamed sample-simple to sample, I forgot to update the root package.json. This broke the build.