### PR TITLE
Remove all references to sample-complex and sample-simple

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,4 +20,3 @@ reactfire/**/*.d.ts
 reactfire/pub/*
 reactfire/docs/reactfire-metadata.json
 .cache
-sample-complex/src/firebase-key.json

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@ node_modules/
 
 
 reactfire/docs/reactfire-metadata.json
-sample-complex/.cache/**
-sample-complex/src/firebase-key.json
 reactfire/firestore-debug.log
 reactfire/pub/**
 pub

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ ENV PYTHON /usr/bin/python2.7
 COPY package.json /
 COPY yarn.lock /
 COPY reactfire/package.json reactfire/
-COPY sample-complex/package.json sample-complex/
-COPY sample-simple/package.json sample-simple/
+COPY sample/package.json sample/
 RUN yarn install --frozen-lockfile
 
 COPY . /

--- a/README.md
+++ b/README.md
@@ -1,17 +1,29 @@
 # Reactfire
 
-Hooks, Context Providers, and Components that make it easy
-to interact with Firebase.
+Hooks, Context Providers, and Components that make it easy to interact with
+Firebase.
 
-> If you're looking for docs for the _deprecated_ ReactFire v1 (the one that uses mixins), click [here](https://github.com/FirebaseExtended/reactfire/tree/v1.0.0)
+> If you're looking for docs for the _deprecated_ ReactFire v1 (the one that
+> uses mixins), click
+> [here](https://github.com/FirebaseExtended/reactfire/tree/v1.0.0)
 
-**Status: Alpha**. ReactFire is meant for React Concurrent Mode, which is only available in [experimental React builds](https://reactjs.org/docs/concurrent-mode-adoption.html#installation).
+**Status: Alpha**. ReactFire is meant for React Concurrent Mode, which is only
+available in
+[experimental React builds](https://reactjs.org/docs/concurrent-mode-adoption.html#installation).
 
 ## What is ReactFire?
 
-- **Easy realtime updates for your function components** - Reactfire's hooks, like `useFirestoreCollection` and `useUser`, let you easily subscribe to events, and automatically unsubscribe when your component unmounts.
-- **Loading states handled by `<Suspense>`** - Reactfire's hooks throw promises that Suspense can catch. No more `isLoaded ?...` - let React [handle it for you](https://reactjs.org/blog/2018/11/27/react-16-roadmap.html#react-166-shipped-the-one-with-suspense-for-code-splitting).
-- **Dead-simple Real User Monitoring (RUM)** - Easily enable Firebase Performance Monitoring's [automatic traces](https://firebase.google.com/docs/perf-mon/automatic-web), and instrument your Suspenseful loads with Reactfire's `<SuspenseWithPerf>` component
+- **Easy realtime updates for your function components** - Reactfire's hooks,
+  like `useFirestoreCollection` and `useUser`, let you easily subscribe to
+  events, and automatically unsubscribe when your component unmounts.
+- **Loading states handled by `<Suspense>`** - Reactfire's hooks throw promises
+  that Suspense can catch. No more `isLoaded ?...` - let React
+  [handle it for you](https://reactjs.org/blog/2018/11/27/react-16-roadmap.html#react-166-shipped-the-one-with-suspense-for-code-splitting).
+- **Dead-simple Real User Monitoring (RUM)** - Easily enable Firebase
+  Performance Monitoring's
+  [automatic traces](https://firebase.google.com/docs/perf-mon/automatic-web),
+  and instrument your Suspenseful loads with Reactfire's `<SuspenseWithPerf>`
+  component
 
 ## Install
 
@@ -26,7 +38,8 @@ If you like living life on the edge, use `reactfire@canary`.
 
 ## Example use
 
-Check out the [live version on StackBlitz](https://stackblitz.com/edit/reactfire-sample)!
+Check out the
+[live version on StackBlitz](https://stackblitz.com/edit/reactfire-sample)!
 
 ```jsx
 import React, { Component } from 'react';
@@ -88,11 +101,15 @@ render(<App />, document.getElementById('root'));
 
 ### For development
 
-1. [Clone](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) this repository (or a [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo#propose-changes-to-someone-elses-project))
+1. [Clone](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository)
+   this repository (or a
+   [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo#propose-changes-to-someone-elses-project))
 1. At the project root, install all modules by running `yarn install`.
 1. `cd` into the _reactfire_ directory. Run `yarn` and `yarn watch`.
-1. In a new terminal, `cd` into the _reactfire/sample-simple_ directory. run `yarn` and `yarn start`.
-1. Head over to https://localhost:3000 to see the running sample! If you edit the reactfire source, the sample will reload.
+1. In a new terminal, `cd` into the _reactfire/sample_ directory. run `yarn` and
+   `yarn start`.
+1. Head over to https://localhost:3000 to see the running sample! If you edit
+   the reactfire source, the sample will reload.
 
 ### Testing
 

--- a/sample/package.json
+++ b/sample/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sample-simple",
+  "name": "sample",
   "version": "0.1.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
I removed the _sample-complex_ folder in [this commit](https://github.com/FirebaseExtended/reactfire/commit/7820b0f1626b1726277b646706a46e0a4539d5c7) because it had fallen out of date. However, I didn't remove it completely. This removes the rest and turns _sample-simple_ into _sample_.