### PR TITLE
Fix build: "sh: 1: node: Permission denied"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -qq curl default-jre < /dev/n
 RUN curl --silent -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.0/install.sh | bash
 COPY .nvmrc /
 RUN nvm install .
-RUN npm install -g yarn firebase-tools
+RUN npm install --unsafe-perm -g yarn firebase-tools
 RUN firebase setup:emulators:firestore
 
 ENV PYTHON /usr/bin/python2.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -qq curl default-jre < /dev/n
 
 RUN curl --silent -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.0/install.sh | bash
 COPY .nvmrc /
-RUN nvm install .
+RUN nvm install
 RUN npm install --unsafe-perm -g yarn firebase-tools
 RUN firebase setup:emulators:firestore
 


### PR DESCRIPTION
The CI build was failing with error `sh: 1: node: Permission denied`

I added `--unsafe-perm` to `npm install` per the recommendation [here](https://stackoverflow.com/a/53270214/4816918).