### PR TITLE
Refactoring use/preload x

### DIFF
--- a/reactfire/.npmignore
+++ b/reactfire/.npmignore
@@ -1,3 +1,2 @@
-cjs/index.esm-*
 **/*.test.d.ts
 **/*.test.js

--- a/reactfire/auth/index.tsx
+++ b/reactfire/auth/index.tsx
@@ -13,7 +13,7 @@ import { from } from 'rxjs';
 export function preloadUser(firebaseApp: firebase.app.App) {
   return preloadAuth(firebaseApp).then(auth => {
     const result = preloadObservable(
-      user(auth() as firebase.auth.Auth),
+      user(auth),
       `auth:user:${firebaseApp.name}`
     );
     return result.toPromise();
@@ -30,7 +30,7 @@ export function useUser<T = unknown>(
   auth?: auth.Auth,
   options?: ReactFireOptions<T>
 ): User | T {
-  auth = auth || useAuth()();
+  auth = auth || useAuth();
   const currentUser = auth.currentUser || options?.startWithValue;
   return useObservable(user(auth), `auth:user:${auth.app.name}`, currentUser);
 }

--- a/reactfire/auth/index.tsx
+++ b/reactfire/auth/index.tsx
@@ -13,7 +13,7 @@ import { from } from 'rxjs';
 export function preloadUser(firebaseApp: firebase.app.App) {
   return preloadAuth(firebaseApp).then(auth => {
     const result = preloadObservable(
-      user(auth),
+      user(auth()),
       `auth:user:${firebaseApp.name}`
     );
     return result.toPromise();

--- a/reactfire/firebaseApp/firebaseApp.test.tsx
+++ b/reactfire/firebaseApp/firebaseApp.test.tsx
@@ -29,25 +29,6 @@ describe('FirebaseAppProvider', () => {
     spy.mockRestore();
   });
 
-  it('initializes fireperf if specified', async () => {
-    const mockPerf = jest.fn();
-    firebase['performance' as any] = mockPerf;
-    const app: firebase.app.App = { performance: mockPerf } as any;
-
-    render(<FirebaseAppProvider firebaseApp={app} initPerformance />);
-
-    expect(mockPerf).toBeCalled();
-  });
-
-  it('does not initialize fireperf if not specified', async () => {
-    const mockPerf = jest.fn();
-    firebase['performance' as any] = mockPerf;
-    const app: firebase.app.App = { performance: mockPerf } as any;
-
-    render(<FirebaseAppProvider firebaseApp={app} />);
-
-    expect(mockPerf).not.toBeCalled();
-  });
 });
 
 describe('useFirebaseApp', () => {

--- a/reactfire/firebaseApp/index.tsx
+++ b/reactfire/firebaseApp/index.tsx
@@ -6,14 +6,13 @@ export * from './sdk';
 type FirebaseAppContextValue = firebase.app.App;
 
 // INVESTIGATE I don't like magic strings, can we have export this in js-sdk?
-const DEFAULT_APP_NAME = '[DEFAULT]';
+export const DEFAULT_APP_NAME = '[DEFAULT]';
 
 const FirebaseAppContext = React.createContext<
   FirebaseAppContextValue | undefined
 >(undefined);
 
 type Props = {
-  initPerformance?: boolean;
   firebaseApp?: firebase.app.App;
   firebaseConfig?: Object;
   appName?: string;
@@ -24,7 +23,7 @@ const shallowEq = (a: Object, b: Object) =>
   [...Object.keys(a), ...Object.keys(b)].every(key => a[key] == b[key]);
 
 export function FirebaseAppProvider(props: Props & { [key: string]: unknown }) {
-  const { firebaseConfig, appName, initPerformance = false } = props;
+  const { firebaseConfig, appName } = props;
   const firebaseApp: firebase.app.App =
     props.firebaseApp ||
     React.useMemo(() => {
@@ -42,19 +41,6 @@ export function FirebaseAppProvider(props: Props & { [key: string]: unknown }) {
         return firebase.initializeApp(firebaseConfig, appName);
       }
     }, [firebaseConfig, appName]);
-
-  React.useMemo(() => {
-    if (initPerformance === true) {
-      if (firebaseApp.performance) {
-        // initialize Performance Monitoring
-        firebaseApp.performance();
-      } else {
-        throw new Error(
-          'firebase.performance not found. Did you forget to import it?'
-        );
-      }
-    }
-  }, [initPerformance, firebaseApp]);
 
   return <FirebaseAppContext.Provider value={firebaseApp} {...props} />;
 }

--- a/reactfire/firebaseApp/sdk.tsx
+++ b/reactfire/firebaseApp/sdk.tsx
@@ -71,11 +71,12 @@ function proxyComponent(
   return new Proxy(componentFn, {
     get: (target, p) => target()[p],
     apply: (target, _this, args) => {
+      const component = target().bind(_this);
       // If they don't pass an app, assume the app in context rather than [DEFAULT]
       if (!args[0]) {
         args[0] = contextualApp;
       }
-      return target().bind(_this)(...args);
+      return component(...args);
     }
   }) as any;
 }

--- a/reactfire/firebaseApp/sdk.tsx
+++ b/reactfire/firebaseApp/sdk.tsx
@@ -1,219 +1,117 @@
-import { useFirebaseApp } from '..';
-import { useObservable } from '../useObservable';
-import { from } from 'rxjs';
 import { DEFAULT_APP_NAME } from '../index';
 
+type ComponentName = "analytics" | "auth" | "database" | "firestore" | "functions" | "messaging" | "performance" | "remoteConfig" | "storage";
+type ValueOf<T> = T[keyof T];
 type App = import('firebase/app').app.App;
-type RemoteConfig = Omit<typeof import('firebase/app').remoteConfig, "*"> & import('firebase/app').remoteConfig.RemoteConfig;
-type Storage = Omit<typeof import('firebase/app').storage, "*"> & import('firebase/app').storage.Storage;
-type Firestore = Omit<typeof import('firebase/app').firestore, "*"> & import('firebase/app').firestore.Firestore;
-type Performance = Omit<typeof import('firebase/app').performance, "*"> & import('firebase/app').performance.Performance;
-type Messaging = Omit<typeof import('firebase/app').messaging, "*"> & import('firebase/app').messaging.Messaging;
-type Functions = Omit<typeof import('firebase/app').functions, "*"> & import('firebase/app').functions.Functions;
-type Database = Omit<typeof import('firebase/app').database, "*"> & import('firebase/app').database.Database;
-type Auth = Omit<typeof import('firebase/app').auth, "*"> & import('firebase/app').auth.Auth;
-type Analytics = Omit<typeof import('firebase/app').analytics, "*"> & import('firebase/app').analytics.Analytics;
+type FirebaseInstanceFactory = ValueOf<Pick<App, ComponentName>>;
+type FirebaseNamespaceComponent = ValueOf<Pick<typeof import('firebase/app'), ComponentName>>;
 
-type FirebaseNamespace =
-  | Analytics
-  | Auth
-  | Database
-  | Firestore
-  | Functions
-  | Messaging
-  | Performance
-  | RemoteConfig
-  | Storage;
-
-const enum SDK {
-  ANALYTICS = 'analytics',
-  AUTH = 'auth',
-  DATABASE = 'database',
-  FIRESTORE = 'firestore',
-  FUNCTIONS = 'functions',
-  MESSAGING = 'messaging',
-  PERFORMANCE = 'performance',
-  REMOTE_CONFIG = 'remoteConfig',
-  STORAGE = 'storage'
+function importSDK(sdk: ComponentName) {
+  switch (sdk) {
+    case "analytics":
+      return import(
+        /* webpackChunkName: "analytics" */ 'firebase/analytics'
+      );
+    case "auth":
+      return import(
+        /* webpackChunkName: "auth" */ 'firebase/auth'
+      );
+    case "database":
+      return import(
+        /* webpackChunkName: "database" */ 'firebase/database'
+      );
+    case "firestore":
+      return import(
+        /* webpackChunkName: "firestore" */ 'firebase/firestore'
+      );
+    case "functions":
+      return import(
+        /* webpackChunkName: "functions" */ 'firebase/functions'
+      );
+    case "messaging":
+      return import(
+        /* webpackChunkName: "messaging" */ 'firebase/messaging'
+      );
+    case "performance":
+      return import(
+        /* webpackChunkName: "performance" */ 'firebase/performance'
+      );
+    case "remoteConfig":
+      return import(
+        /* webpackChunkName: "remoteConfig" */ 'firebase/remote-config'
+      );
+    case "storage":
+      return import(
+        /* webpackChunkName: "storage" */ 'firebase/storage'
+      );
+  }
 }
 
-function fetchSDK(
-  sdk: SDK,
-  firebaseApp: App,
-  settingsCallback?: (sdk: FirebaseNamespace) => any
+let firebase: typeof import('firebase/app') | undefined;
+
+function useFirebaseComponent(
+  componentName: ComponentName
 ) {
-  if (!firebaseApp) {
-    throw new Error('Firebase app was not provided');
-  }
-  if (firebaseApp[sdk]) {
-    // Don't apply settings here. Only needed for lazy loaded SDKs.
-    // If not lazy loaded, user can provide settings as normal
-    if (settingsCallback) { console.warn(`${sdk} was already initialized on ${firebaseApp.name == DEFAULT_APP_NAME ? 'the default app' : firebaseApp.name }, ignoring settingsCallback`) }
-    // TODO cleanup types, this is an internal API
-    const serviceProps = (firebaseApp as any).container?.providers?.get(sdk)?.component?.serviceProps ?? {};
-    const component = firebaseApp[sdk]();
-    const proxy = new Proxy(component, { get: (target, p) => serviceProps[p] ?? target[p] }) as FirebaseNamespace;
-    return Promise.resolve(proxy);
-  } else {
-    let sdkPromise: Promise<FirebaseNamespace>;
-    switch (sdk) {
-      case SDK.ANALYTICS:
-        sdkPromise = import(
-          /* webpackChunkName: "analytics" */ 'firebase/analytics'
-        );
-        break;
-      case SDK.AUTH:
-        sdkPromise = import(/* webpackChunkName: "auth" */ 'firebase/auth');
-        break;
-      case SDK.DATABASE:
-        sdkPromise = import(
-          /* webpackChunkName: "database" */ 'firebase/database'
-        );
-        break;
-      case SDK.FIRESTORE:
-        sdkPromise = import(
-          /* webpackChunkName: "firestore" */ 'firebase/firestore'
-        );
-        break;
-      case SDK.FUNCTIONS:
-        sdkPromise = import(
-          /* webpackChunkName: "functions" */ 'firebase/functions'
-        );
-        break;
-      case SDK.MESSAGING:
-        sdkPromise = import(
-          /* webpackChunkName: "messaging" */ 'firebase/messaging'
-        );
-        break;
-      case SDK.PERFORMANCE:
-        sdkPromise = import(
-          /* webpackChunkName: "performance" */ 'firebase/performance'
-        );
-        break;
-      case SDK.REMOTE_CONFIG:
-        sdkPromise = import(
-          /* webpackChunkName: "remoteConfig" */ 'firebase/remote-config'
-        );
-        break;
-      case SDK.STORAGE:
-        sdkPromise = import(
-          /* webpackChunkName: "storage" */ 'firebase/storage'
-        );
-        break;
+  if (!firebase) { throw import('firebase/app').then(it => firebase = it); }
+  if (!firebase[componentName]) { throw importSDK(componentName); }
+  return firebase[componentName];
+}
+
+function proxyComponent(componentName: "auth"        ): typeof import('firebase/app').auth;
+function proxyComponent(componentName: "analytics"   ): typeof import('firebase/app').analytics;
+function proxyComponent(componentName: "database"    ): typeof import('firebase/app').database;
+function proxyComponent(componentName: "firestore"   ): typeof import('firebase/app').firestore;
+function proxyComponent(componentName: "functions"   ): typeof import('firebase/app').functions;
+function proxyComponent(componentName: "messaging"   ): typeof import('firebase/app').messaging;
+function proxyComponent(componentName: "performance" ): typeof import('firebase/app').performance;
+function proxyComponent(componentName: "remoteConfig"): typeof import('firebase/app').remoteConfig;
+function proxyComponent(componentName: "storage"     ): typeof import('firebase/app').storage;
+function proxyComponent(componentName: ComponentName): FirebaseNamespaceComponent {
+  return new Proxy(() => useFirebaseComponent(componentName), {
+    get: (target, p) => target()[p],
+    apply: (target, _this, args) => target().bind(_this)(...args)
+  }) as any;
+}
+
+export const useAuth         = proxyComponent("auth");
+export const useAnalytics    = proxyComponent("analytics");
+export const useDatabase     = proxyComponent("database");
+export const useFirestore    = proxyComponent("firestore");
+export const useFunctions    = proxyComponent("functions");
+export const useMessaging    = proxyComponent("messaging");
+export const usePerformance  = proxyComponent("performance");
+export const useRemoteConfig = proxyComponent("remoteConfig");
+export const useStorage      = proxyComponent("storage");
+
+function preload(componentName: "auth"        ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["auth"])         => any) => Promise<App["auth"]>);
+function preload(componentName: "analytics"   ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["analytics"])    => any) => Promise<App["analytics"]>);
+function preload(componentName: "database"    ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["database"])     => any) => Promise<App["database"]>);
+function preload(componentName: "firestore"   ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["firestore"])    => any) => Promise<App["firestore"]>);
+function preload(componentName: "functions"   ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["functions"])    => any) => Promise<App["functions"]>);
+function preload(componentName: "messaging"   ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["messaging"])    => any) => Promise<App["messaging"]>);
+function preload(componentName: "performance" ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["performance"])  => any) => Promise<App["performance"]>);
+function preload(componentName: "remoteConfig"): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["remoteConfig"]) => any) => Promise<App["remoteConfig"]>);
+function preload(componentName: "storage"     ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["storage"])      => any) => Promise<App["storage"]>);
+function preload(componentName: ComponentName) {
+  return async (firebaseApp: App, settingsCallback?: (instanceFactory: FirebaseInstanceFactory) => any) => {
+    const initialized = !!firebaseApp[componentName];
+    if (!initialized) { await importSDK(componentName); }
+    const instanceFactory = firebaseApp[componentName].bind(firebaseApp) as FirebaseInstanceFactory;
+    if (initialized) {
+      if (settingsCallback) { console.warn(`${componentName} was already initialized on ${firebaseApp.name == DEFAULT_APP_NAME ? 'the default app' : firebaseApp.name }, ignoring settingsCallback`) }
+    } else if (settingsCallback) {
+      await Promise.resolve(settingsCallback(instanceFactory)); 
     }
-    return sdkPromise
-      .then(() => Promise.resolve(settingsCallback && settingsCallback(firebaseApp[sdk].bind(firebaseApp))))
-      .then(() => {
-        // TODO cleanup types, this is an internal API
-        const serviceProps = (firebaseApp as any).container?.providers?.get(sdk)?.component?.serviceProps ?? {};
-        const component = firebaseApp[sdk]();
-        return new Proxy(component, { get: (target, p) => serviceProps[p] ?? target[p] }) as FirebaseNamespace;
-      });
-  }
+    return instanceFactory;
+  };
 }
 
-function useSDK(sdk: SDK, firebaseApp?: App) {
-  firebaseApp = firebaseApp || useFirebaseApp();
-
-  // use the request cache so we don't issue multiple fetches for the sdk
-  return useObservable(
-    from(fetchSDK(sdk, firebaseApp)),
-    `firebase:sdk-${sdk}:${firebaseApp.name}`
-  );
-}
-
-export function preloadAuth(
-  firebaseApp: App,
-  settingsCallback?: (auth: Auth) => void
-) {
-  return fetchSDK(SDK.AUTH, firebaseApp, settingsCallback) as Promise<Auth>;
-}
-
-export function useAuth(firebaseApp?: App) {
-  return useSDK(SDK.AUTH, firebaseApp) as Auth;
-}
-
-export function preloadAnalytics(firebaseApp: App) {
-  return fetchSDK(SDK.ANALYTICS, firebaseApp) as Promise<Analytics>;
-}
-
-export function useAnalytics(firebaseApp?: App) {
-  return useSDK(SDK.ANALYTICS, firebaseApp) as Analytics;
-}
-
-export function preloadDatabase(
-  firebaseApp: App,
-  settingsCallback?: (database: Database) => void
-) {
-  return fetchSDK(SDK.DATABASE, firebaseApp, settingsCallback) as Promise<Database>;
-}
-
-export function useDatabase(firebaseApp?: App) {
-  return useSDK(SDK.DATABASE, firebaseApp) as Database;
-}
-
-export function preloadFirestore(
-  firebaseApp: App,
-  settingsCallback?: (firestore: Firestore) => void|Promise<any>
-) {
-  return fetchSDK(SDK.FIRESTORE, firebaseApp, settingsCallback) as Promise<Firestore>;
-}
-
-export function useFirestore(firebaseApp?: App) {
-  return useSDK(SDK.FIRESTORE, firebaseApp) as Firestore;
-}
-
-export function preloadFunctions(
-  firebaseApp?: App,
-  settingsCallback?: (functions: Functions) => void
-) {
-  return fetchSDK(SDK.FUNCTIONS, firebaseApp, settingsCallback) as Promise<Functions>;
-}
-
-export function useFunctions(firebaseApp?: App) {
-  return useSDK(SDK.FUNCTIONS, firebaseApp) as Functions;
-}
-
-export function preloadMessaging(
-  firebaseApp: App,
-  settingsCallback?: (messaging: Messaging) => void
-) {
-  return fetchSDK(SDK.MESSAGING, firebaseApp, settingsCallback) as Promise<Messaging>;
-}
-
-export function useMessaging(firebaseApp?: App) {
-  return useSDK(SDK.MESSAGING, firebaseApp) as Messaging;
-}
-
-export function preloadPerformance(
-  firebaseApp: App,
-  settingsCallback?: (performance: Performance) => void
-) {
-  return fetchSDK(SDK.PERFORMANCE, firebaseApp, settingsCallback)  as Promise<Performance>;
-}
-
-export function usePerformance(firebaseApp?: App) {
-  return useSDK(SDK.PERFORMANCE, firebaseApp) as Performance;
-}
-
-export function preloadRemoteConfig(
-  firebaseApp: App,
-  settingsCallback?: (remoteConfig: RemoteConfig) => void|Promise<any>
-) {
-  return fetchSDK(SDK.REMOTE_CONFIG, firebaseApp, settingsCallback)  as Promise<RemoteConfig>;
-}
-
-export function useRemoteConfig(firebaseApp?: App) {
-  return useSDK(SDK.REMOTE_CONFIG, firebaseApp) as RemoteConfig;
-}
-
-export function preloadStorage(
-  firebaseApp: App,
-  settingsCallback: (storage: Storage) => void|Promise<any>
-) {
-  return fetchSDK(SDK.STORAGE, firebaseApp, settingsCallback) as Promise<Storage>;
-}
-
-export function useStorage(firebaseApp?: App) {
-  return useSDK(SDK.STORAGE, firebaseApp) as Storage;
-}
+export const preloadAuth         = preload("auth");
+export const preloadAnalytics    = preload("analytics");
+export const preloadDatabase     = preload("database");
+export const preloadFirestore    = preload("firestore");
+export const preloadFunctions    = preload("functions");
+export const preloadMessaging    = preload("messaging");
+export const preloadPerformance  = preload("performance");
+export const preloadRemoteConfig = preload("remoteConfig");
+export const preloadStorage      = preload("storage");

--- a/reactfire/firebaseApp/sdk.tsx
+++ b/reactfire/firebaseApp/sdk.tsx
@@ -168,7 +168,6 @@ function preload(componentName: ComponentName) {
     } else if (settingsCallback) {
       await Promise.resolve(settingsCallback(instanceFactory));
     }
-    instanceFactory(); // make preload eager by calling the factory
     return instanceFactory;
   };
 }

--- a/reactfire/firebaseApp/sdk.tsx
+++ b/reactfire/firebaseApp/sdk.tsx
@@ -1,117 +1,184 @@
 import { DEFAULT_APP_NAME } from '../index';
+import { useFirebaseApp } from '.';
+import * as firebase from 'firebase/app';
 
-type ComponentName = "analytics" | "auth" | "database" | "firestore" | "functions" | "messaging" | "performance" | "remoteConfig" | "storage";
+type ComponentName =
+  | 'analytics'
+  | 'auth'
+  | 'database'
+  | 'firestore'
+  | 'functions'
+  | 'messaging'
+  | 'performance'
+  | 'remoteConfig'
+  | 'storage';
 type ValueOf<T> = T[keyof T];
-type App = import('firebase/app').app.App;
+type App = firebase.app.App;
 type FirebaseInstanceFactory = ValueOf<Pick<App, ComponentName>>;
-type FirebaseNamespaceComponent = ValueOf<Pick<typeof import('firebase/app'), ComponentName>>;
+type FirebaseNamespaceComponent = ValueOf<Pick<typeof firebase, ComponentName>>;
 
 function importSDK(sdk: ComponentName) {
   switch (sdk) {
-    case "analytics":
-      return import(
-        /* webpackChunkName: "analytics" */ 'firebase/analytics'
-      );
-    case "auth":
-      return import(
-        /* webpackChunkName: "auth" */ 'firebase/auth'
-      );
-    case "database":
-      return import(
-        /* webpackChunkName: "database" */ 'firebase/database'
-      );
-    case "firestore":
-      return import(
-        /* webpackChunkName: "firestore" */ 'firebase/firestore'
-      );
-    case "functions":
-      return import(
-        /* webpackChunkName: "functions" */ 'firebase/functions'
-      );
-    case "messaging":
-      return import(
-        /* webpackChunkName: "messaging" */ 'firebase/messaging'
-      );
-    case "performance":
+    case 'analytics':
+      return import(/* webpackChunkName: "analytics" */ 'firebase/analytics');
+    case 'auth':
+      return import(/* webpackChunkName: "auth" */ 'firebase/auth');
+    case 'database':
+      return import(/* webpackChunkName: "database" */ 'firebase/database');
+    case 'firestore':
+      return import(/* webpackChunkName: "firestore" */ 'firebase/firestore');
+    case 'functions':
+      return import(/* webpackChunkName: "functions" */ 'firebase/functions');
+    case 'messaging':
+      return import(/* webpackChunkName: "messaging" */ 'firebase/messaging');
+    case 'performance':
       return import(
         /* webpackChunkName: "performance" */ 'firebase/performance'
       );
-    case "remoteConfig":
+    case 'remoteConfig':
       return import(
         /* webpackChunkName: "remoteConfig" */ 'firebase/remote-config'
       );
-    case "storage":
-      return import(
-        /* webpackChunkName: "storage" */ 'firebase/storage'
-      );
+    case 'storage':
+      return import(/* webpackChunkName: "storage" */ 'firebase/storage');
   }
 }
 
-let firebase: typeof import('firebase/app') | undefined;
-
-function useFirebaseComponent(
+function proxyComponent(componentName: 'auth'): typeof firebase.auth;
+function proxyComponent(componentName: 'analytics'): typeof firebase.analytics;
+function proxyComponent(componentName: 'database'): typeof firebase.database;
+function proxyComponent(componentName: 'firestore'): typeof firebase.firestore;
+function proxyComponent(componentName: 'functions'): typeof firebase.functions;
+function proxyComponent(componentName: 'messaging'): typeof firebase.messaging;
+function proxyComponent(
+  componentName: 'performance'
+): typeof firebase.performance;
+function proxyComponent(
+  componentName: 'remoteConfig'
+): typeof firebase.remoteConfig;
+function proxyComponent(componentName: 'storage'): typeof firebase.storage;
+function proxyComponent(
   componentName: ComponentName
-) {
-  if (!firebase) { throw import('firebase/app').then(it => firebase = it); }
-  if (!firebase[componentName]) { throw importSDK(componentName); }
-  return firebase[componentName];
-}
-
-function proxyComponent(componentName: "auth"        ): typeof import('firebase/app').auth;
-function proxyComponent(componentName: "analytics"   ): typeof import('firebase/app').analytics;
-function proxyComponent(componentName: "database"    ): typeof import('firebase/app').database;
-function proxyComponent(componentName: "firestore"   ): typeof import('firebase/app').firestore;
-function proxyComponent(componentName: "functions"   ): typeof import('firebase/app').functions;
-function proxyComponent(componentName: "messaging"   ): typeof import('firebase/app').messaging;
-function proxyComponent(componentName: "performance" ): typeof import('firebase/app').performance;
-function proxyComponent(componentName: "remoteConfig"): typeof import('firebase/app').remoteConfig;
-function proxyComponent(componentName: "storage"     ): typeof import('firebase/app').storage;
-function proxyComponent(componentName: ComponentName): FirebaseNamespaceComponent {
-  return new Proxy(() => useFirebaseComponent(componentName), {
+): FirebaseNamespaceComponent {
+  let contextualApp: App | undefined;
+  const componentFn = () => {
+    contextualApp = useFirebaseApp();
+    if (!firebase[componentName]) {
+      throw importSDK(componentName);
+    }
+    return firebase[componentName];
+  };
+  return new Proxy(componentFn, {
     get: (target, p) => target()[p],
-    apply: (target, _this, args) => target().bind(_this)(...args)
+    apply: (target, _this, args) => {
+      // If they don't pass an app, assume the app in context rather than [DEFAULT]
+      if (!args[0]) {
+        args[0] = contextualApp;
+      }
+      return target().bind(_this)(...args);
+    }
   }) as any;
 }
 
-export const useAuth         = proxyComponent("auth");
-export const useAnalytics    = proxyComponent("analytics");
-export const useDatabase     = proxyComponent("database");
-export const useFirestore    = proxyComponent("firestore");
-export const useFunctions    = proxyComponent("functions");
-export const useMessaging    = proxyComponent("messaging");
-export const usePerformance  = proxyComponent("performance");
-export const useRemoteConfig = proxyComponent("remoteConfig");
-export const useStorage      = proxyComponent("storage");
+export const useAuth = proxyComponent('auth');
+export const useAnalytics = proxyComponent('analytics');
+export const useDatabase = proxyComponent('database');
+export const useFirestore = proxyComponent('firestore');
+export const useFunctions = proxyComponent('functions');
+export const useMessaging = proxyComponent('messaging');
+export const usePerformance = proxyComponent('performance');
+export const useRemoteConfig = proxyComponent('remoteConfig');
+export const useStorage = proxyComponent('storage');
 
-function preload(componentName: "auth"        ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["auth"])         => any) => Promise<App["auth"]>);
-function preload(componentName: "analytics"   ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["analytics"])    => any) => Promise<App["analytics"]>);
-function preload(componentName: "database"    ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["database"])     => any) => Promise<App["database"]>);
-function preload(componentName: "firestore"   ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["firestore"])    => any) => Promise<App["firestore"]>);
-function preload(componentName: "functions"   ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["functions"])    => any) => Promise<App["functions"]>);
-function preload(componentName: "messaging"   ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["messaging"])    => any) => Promise<App["messaging"]>);
-function preload(componentName: "performance" ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["performance"])  => any) => Promise<App["performance"]>);
-function preload(componentName: "remoteConfig"): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["remoteConfig"]) => any) => Promise<App["remoteConfig"]>);
-function preload(componentName: "storage"     ): ((firebaseApp: App, settingsCallback?: (instanceFactory: App["storage"])      => any) => Promise<App["storage"]>);
+function preload(
+  componentName: 'auth'
+): (
+  firebaseApp?: App,
+  settingsCallback?: (instanceFactory: App['auth']) => any
+) => Promise<App['auth']>;
+function preload(
+  componentName: 'analytics'
+): (
+  firebaseApp?: App,
+  settingsCallback?: (instanceFactory: App['analytics']) => any
+) => Promise<App['analytics']>;
+function preload(
+  componentName: 'database'
+): (
+  firebaseApp?: App,
+  settingsCallback?: (instanceFactory: App['database']) => any
+) => Promise<App['database']>;
+function preload(
+  componentName: 'firestore'
+): (
+  firebaseApp?: App,
+  settingsCallback?: (instanceFactory: App['firestore']) => any
+) => Promise<App['firestore']>;
+function preload(
+  componentName: 'functions'
+): (
+  firebaseApp?: App,
+  settingsCallback?: (instanceFactory: App['functions']) => any
+) => Promise<App['functions']>;
+function preload(
+  componentName: 'messaging'
+): (
+  firebaseApp?: App,
+  settingsCallback?: (instanceFactory: App['messaging']) => any
+) => Promise<App['messaging']>;
+function preload(
+  componentName: 'performance'
+): (
+  firebaseApp?: App,
+  settingsCallback?: (instanceFactory: App['performance']) => any
+) => Promise<App['performance']>;
+function preload(
+  componentName: 'remoteConfig'
+): (
+  firebaseApp?: App,
+  settingsCallback?: (instanceFactory: App['remoteConfig']) => any
+) => Promise<App['remoteConfig']>;
+function preload(
+  componentName: 'storage'
+): (
+  firebaseApp?: App,
+  settingsCallback?: (instanceFactory: App['storage']) => any
+) => Promise<App['storage']>;
 function preload(componentName: ComponentName) {
-  return async (firebaseApp: App, settingsCallback?: (instanceFactory: FirebaseInstanceFactory) => any) => {
-    const initialized = !!firebaseApp[componentName];
-    if (!initialized) { await importSDK(componentName); }
-    const instanceFactory = firebaseApp[componentName].bind(firebaseApp) as FirebaseInstanceFactory;
-    if (initialized) {
-      if (settingsCallback) { console.warn(`${componentName} was already initialized on ${firebaseApp.name == DEFAULT_APP_NAME ? 'the default app' : firebaseApp.name }, ignoring settingsCallback`) }
-    } else if (settingsCallback) {
-      await Promise.resolve(settingsCallback(instanceFactory)); 
+  return async (
+    firebaseApp?: App,
+    settingsCallback?: (instanceFactory: FirebaseInstanceFactory) => any
+  ) => {
+    const app = firebaseApp || useFirebaseApp();
+    const initialized = !!app[componentName];
+    if (!initialized) {
+      await importSDK(componentName);
     }
+    const instanceFactory = app[componentName].bind(
+      app
+    ) as FirebaseInstanceFactory;
+    if (initialized) {
+      if (settingsCallback) {
+        console.warn(
+          `${componentName} was already initialized on ${
+            app.name == DEFAULT_APP_NAME ? 'the default app' : app.name
+          }, ignoring settingsCallback`
+        );
+      }
+    } else if (settingsCallback) {
+      await Promise.resolve(settingsCallback(instanceFactory));
+    }
+    instanceFactory(); // make preload eager by calling the factory
     return instanceFactory;
   };
 }
 
-export const preloadAuth         = preload("auth");
-export const preloadAnalytics    = preload("analytics");
-export const preloadDatabase     = preload("database");
-export const preloadFirestore    = preload("firestore");
-export const preloadFunctions    = preload("functions");
-export const preloadMessaging    = preload("messaging");
-export const preloadPerformance  = preload("performance");
-export const preloadRemoteConfig = preload("remoteConfig");
-export const preloadStorage      = preload("storage");
+export const preloadAuth = preload('auth');
+export const preloadAnalytics = preload('analytics');
+export const preloadDatabase = preload('database');
+export const preloadFirestore = preload('firestore');
+export const preloadFunctions = preload('functions');
+export const preloadMessaging = preload('messaging');
+export const preloadPerformance = preload('performance');
+export const preloadRemoteConfig = preload('remoteConfig');
+export const preloadStorage = preload('storage');

--- a/reactfire/firebaseApp/sdk.tsx
+++ b/reactfire/firebaseApp/sdk.tsx
@@ -12,6 +12,7 @@ type ComponentName =
   | 'performance'
   | 'remoteConfig'
   | 'storage';
+
 type ValueOf<T> = T[keyof T];
 type App = firebase.app.App;
 type FirebaseInstanceFactory = ValueOf<Pick<App, ComponentName>>;
@@ -61,14 +62,14 @@ function proxyComponent(
   componentName: ComponentName
 ): FirebaseNamespaceComponent {
   let contextualApp: App | undefined;
-  const componentFn = () => {
+  const useComponent = () => {
     contextualApp = useFirebaseApp();
     if (!firebase[componentName]) {
       throw importSDK(componentName);
     }
     return firebase[componentName];
   };
-  return new Proxy(componentFn, {
+  return new Proxy(useComponent, {
     get: (target, p) => target()[p],
     apply: (target, _this, args) => {
       const component = target().bind(_this);
@@ -90,6 +91,16 @@ export const useMessaging = proxyComponent('messaging');
 export const usePerformance = proxyComponent('performance');
 export const useRemoteConfig = proxyComponent('remoteConfig');
 export const useStorage = proxyComponent('storage');
+
+export const auth = useAuth;
+export const analytics = useAnalytics;
+export const database = useDatabase;
+export const firestore = useFirestore;
+export const functions = useFunctions;
+export const messaging = useMessaging;
+export const performance = usePerformance;
+export const remoteConfig = useRemoteConfig;
+export const storage = useStorage;
 
 function preload(
   componentName: 'auth'

--- a/reactfire/firestore/index.tsx
+++ b/reactfire/firestore/index.tsx
@@ -28,7 +28,7 @@ export function preloadFirestoreDoc(
   firebaseApp: firebase.app.App
 ) {
   return preloadFirestore(firebaseApp).then(firestore => {
-    const ref = refProvider(firestore);
+    const ref = refProvider(firestore());
     return preloadObservable(
       doc(ref),
       `firestore:doc:${ref.firestore.app.name}:${ref.path}`

--- a/reactfire/firestore/index.tsx
+++ b/reactfire/firestore/index.tsx
@@ -28,7 +28,7 @@ export function preloadFirestoreDoc(
   firebaseApp: firebase.app.App
 ) {
   return preloadFirestore(firebaseApp).then(firestore => {
-    const ref = refProvider(firestore() as firebase.firestore.Firestore);
+    const ref = refProvider(firestore);
     return preloadObservable(
       doc(ref),
       `firestore:doc:${ref.firestore.app.name}:${ref.path}`

--- a/reactfire/performance/index.tsx
+++ b/reactfire/performance/index.tsx
@@ -1,12 +1,11 @@
-import { performance } from 'firebase/app';
 import * as React from 'react';
-import { usePerformance } from '../firebaseApp';
+import { preloadPerformance } from '../firebaseApp';
 
 export interface SuspensePerfProps {
   children: React.ReactNode;
   traceId: string;
   fallback: React.ReactNode;
-  firePerf?: performance.Performance;
+  firePerf?: import('firebase/app').performance.Performance;
 }
 
 export function SuspenseWithPerf({
@@ -15,15 +14,20 @@ export function SuspenseWithPerf({
   fallback,
   firePerf
 }: SuspensePerfProps): JSX.Element {
-  firePerf = firePerf || usePerformance();
+  if (!firePerf) {
+    preloadPerformance();
+  }
+
+  const startMarkName = `${traceId}[${Math.random().toString(36)}]`;
+  const endMarkName = `${traceId}[${Math.random().toString(36)}]`;
 
   const Fallback = () => {
     React.useLayoutEffect(() => {
-      const trace = firePerf.trace(traceId);
-      trace.start();
+      performance?.mark(startMarkName);
 
       return () => {
-        trace.stop();
+        performance?.mark(endMarkName);
+        performance?.measure(traceId, startMarkName, endMarkName);
       };
     }, [traceId]);
 

--- a/reactfire/performance/index.tsx
+++ b/reactfire/performance/index.tsx
@@ -18,21 +18,17 @@ export function SuspenseWithPerf({
     preloadPerformance().then(perf => perf());
   }
 
-  const mark = performance?.mark || (() => {});
-  const measure = performance?.measure || (() => {});
-  const getEntriesByName = performance?.getEntriesByName || (() => []);
-
-  const entries = getEntriesByName(traceId, 'measure');
+  const entries = performance?.getEntriesByName(traceId, 'measure') || [];
   const startMarkName = `_${traceId}Start[${entries.length}]`;
   const endMarkName = `_${traceId}End[${entries.length}]`;
 
   const Fallback = () => {
     React.useLayoutEffect(() => {
-      mark(startMarkName);
+      performance?.mark(startMarkName);
 
       return () => {
-        mark(endMarkName);
-        measure(traceId, startMarkName, endMarkName);
+        performance?.mark(endMarkName);
+        performance?.measure(traceId, startMarkName, endMarkName);
       };
     }, [traceId]);
 

--- a/reactfire/performance/index.tsx
+++ b/reactfire/performance/index.tsx
@@ -1,6 +1,6 @@
 import { performance } from 'firebase/app';
 import * as React from 'react';
-import { useFirebaseApp } from '..';
+import { usePerformance } from '../firebaseApp';
 
 export interface SuspensePerfProps {
   children: React.ReactNode;
@@ -9,32 +9,13 @@ export interface SuspensePerfProps {
   firePerf?: performance.Performance;
 }
 
-function getPerfFromContext(): performance.Performance {
-  const firebaseApp = useFirebaseApp();
-  if (!firebaseApp) {
-    throw new Error(
-      'Firebase not found in context. Either pass it directly to a reactfire hook, or wrap your component in a FirebaseAppProvider'
-    );
-  }
-
-  const perfFunc = firebaseApp.performance;
-
-  if (!perfFunc || !perfFunc()) {
-    throw new Error(
-      "No perf object off of Firebase. Did you forget to import 'firebase/performance' in a component?"
-    );
-  }
-
-  return perfFunc();
-}
-
 export function SuspenseWithPerf({
   children,
   traceId,
   fallback,
   firePerf
 }: SuspensePerfProps): JSX.Element {
-  firePerf = firePerf || getPerfFromContext();
+  firePerf = firePerf || usePerformance();
 
   const Fallback = () => {
     React.useLayoutEffect(() => {

--- a/reactfire/performance/index.tsx
+++ b/reactfire/performance/index.tsx
@@ -15,19 +15,24 @@ export function SuspenseWithPerf({
   firePerf
 }: SuspensePerfProps): JSX.Element {
   if (!firePerf) {
-    preloadPerformance();
+    preloadPerformance().then(perf => perf());
   }
 
-  const startMarkName = `${traceId}[${Math.random().toString(36)}]`;
-  const endMarkName = `${traceId}[${Math.random().toString(36)}]`;
+  const mark = performance?.mark || (() => {});
+  const measure = performance?.measure || (() => {});
+  const getEntriesByName = performance?.getEntriesByName || (() => []);
+
+  const entries = getEntriesByName(traceId, 'measure');
+  const startMarkName = `_${traceId}Start[${entries.length}]`;
+  const endMarkName = `_${traceId}End[${entries.length}]`;
 
   const Fallback = () => {
     React.useLayoutEffect(() => {
-      performance?.mark(startMarkName);
+      mark(startMarkName);
 
       return () => {
-        performance?.mark(endMarkName);
-        performance?.measure(traceId, startMarkName, endMarkName);
+        mark(endMarkName);
+        measure(traceId, startMarkName, endMarkName);
       };
     }, [traceId]);
 

--- a/reactfire/performance/performance.test.tsx
+++ b/reactfire/performance/performance.test.tsx
@@ -23,9 +23,11 @@ const mockFirebase: firebase.app.App = {
 
 const mark = jest.fn();
 const measure = jest.fn();
+const getEntriesByName = jest.fn(() => []);
 
 window.performance.mark = mark;
 window.performance.measure = measure;
+window.performance.getEntriesByName = getEntriesByName;
 
 const PromiseThrower = () => {
   throw new Promise((resolve, reject) => {});

--- a/reactfire/remote-config/index.tsx
+++ b/reactfire/remote-config/index.tsx
@@ -32,7 +32,7 @@ function typeSafeUse<T>(
   getter: Getter$<T>,
   remoteConfig?: RemoteConfig
 ): T {
-  remoteConfig = remoteConfig || useRemoteConfig()();
+  remoteConfig = remoteConfig || useRemoteConfig();
   // INVESTIGATE need to use a public API to get at the app name, one doesn't appear to exist...
   // we might need to iterate over the Firebase apps and check for remoteConfig equality? this works for now
   const appName = (remoteConfig as RemoteConfigWithPrivate)._storage?.appName;

--- a/reactfire/rollup.config.js
+++ b/reactfire/rollup.config.js
@@ -18,5 +18,6 @@ export default {
     'rxjs/operators',
     'tslib'
   ],
-  plugins: [resolve()]
+  plugins: [resolve()],
+  inlineDynamicImports: true
 };

--- a/reactfire/rollup.config.js
+++ b/reactfire/rollup.config.js
@@ -7,17 +7,7 @@ export default {
     format: 'cjs',
     name: 'reactfire'
   },
-  external: [
-    'react',
-    'firebase/app',
-    'rxfire/auth',
-    'rxfire/database',
-    'rxfire/firestore',
-    'rxfire/storage',
-    'rxjs',
-    'rxjs/operators',
-    'tslib'
-  ],
+  external: id => !id.startsWith('.'),
   plugins: [resolve()],
   inlineDynamicImports: true
 };

--- a/reactfire/rollup.config.js
+++ b/reactfire/rollup.config.js
@@ -8,6 +8,5 @@ export default {
     name: 'reactfire'
   },
   external: id => !id.startsWith('.'),
-  plugins: [resolve()],
-  inlineDynamicImports: true
+  plugins: [resolve()]
 };

--- a/sample/package.json
+++ b/sample/package.json
@@ -8,8 +8,7 @@
     "react": "0.0.0-experimental-f42431abe",
     "react-dom": "0.0.0-experimental-f42431abe",
     "react-firebaseui": "^4.0.0",
-    "react-scripts": "3.3.0",
-    "reactfire": "2.0.0"
+    "react-scripts": "3.3.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/sample/src/Auth.js
+++ b/sample/src/Auth.js
@@ -25,7 +25,7 @@ const UserDetails = ({ user }) => {
 };
 
 const SignInForm = () => {
-  const auth = useAuth();
+  const auth = useAuth;
 
   const uiConfig = {
     signInFlow: 'popup',
@@ -36,7 +36,7 @@ const SignInForm = () => {
     }
   };
 
-  return <StyledFirebaseAuth uiConfig={uiConfig} firebaseAuth={auth} />;
+  return <StyledFirebaseAuth uiConfig={uiConfig} firebaseAuth={auth()} />;
 };
 
 const FirebaseAuthStateButton = () => {

--- a/sample/src/Auth.js
+++ b/sample/src/Auth.js
@@ -3,7 +3,7 @@ import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth';
 import { SuspenseWithPerf, useUser, useAuth } from 'reactfire';
 
 const signOut = auth =>
-  auth()
+  auth
     .signOut()
     .then(() => console.log('signed out'));
 
@@ -36,7 +36,7 @@ const SignInForm = () => {
     }
   };
 
-  return <StyledFirebaseAuth uiConfig={uiConfig} firebaseAuth={auth()} />;
+  return <StyledFirebaseAuth uiConfig={uiConfig} firebaseAuth={auth} />;
 };
 
 const FirebaseAuthStateButton = () => {

--- a/sample/src/Firestore.js
+++ b/sample/src/Firestore.js
@@ -11,10 +11,10 @@ import {
 
 const Counter = props => {
   const firestore = useFirestore();
-
+  
   const serverIncrement = firestore.FieldValue.increment;
 
-  const ref = firestore().doc('count/counter');
+  const ref = firestore.doc('count/counter');
 
   const increment = amountToIncrement => {
     ref.update({
@@ -36,7 +36,7 @@ const Counter = props => {
 const StaticValue = props => {
   const firestore = useFirestore();
 
-  const ref = firestore().doc('count/counter');
+  const ref = firestore.doc('count/counter');
 
   const { value } = useFirestoreDocDataOnce(ref);
 
@@ -86,7 +86,7 @@ const List = ({ query, removeAnimal }) => {
 
 const FavoriteAnimals = props => {
   const firestore = useFirestore();
-  const baseRef = firestore().collection('animals');
+  const baseRef = firestore.collection('animals');
   const [isAscending, setIsAscending] = useState(true);
   const query = baseRef.orderBy('commonName', isAscending ? 'asc' : 'desc');
   const [startTransition, isPending] = useTransition({

--- a/sample/src/Firestore.js
+++ b/sample/src/Firestore.js
@@ -10,11 +10,11 @@ import {
 } from 'reactfire';
 
 const Counter = props => {
-  const firestore = useFirestore();
+  const firestore = useFirestore;
   
   const serverIncrement = firestore.FieldValue.increment;
 
-  const ref = firestore.doc('count/counter');
+  const ref = firestore().doc('count/counter');
 
   const increment = amountToIncrement => {
     ref.update({

--- a/sample/src/RealtimeDatabase.js
+++ b/sample/src/RealtimeDatabase.js
@@ -9,7 +9,7 @@ import {
 
 const Counter = props => {
   const database = useDatabase();
-  const ref = database().ref('counter');
+  const ref = database.ref('counter');
   const increment = amountToIncrement => {
     ref.transaction(counterVal => {
       return counterVal + amountToIncrement;
@@ -56,7 +56,7 @@ const AnimalEntry = ({ saveAnimal }) => {
 
 const List = props => {
   const database = useDatabase();
-  const ref = database().ref('animals');
+  const ref = database.ref('animals');
   const animals = useDatabaseListData(ref, { idField: 'id' });
 
   const addNewAnimal = commonName => {

--- a/sample/src/Storage.js
+++ b/sample/src/Storage.js
@@ -27,7 +27,7 @@ const ImageUploadButton = props => {
     const fileList = event.target.files;
     const fileToUpload = fileList[0];
     const fileName = fileToUpload.name;
-    const newRef = storage()
+    const newRef = storage
       .ref('images')
       .child(fileName);
     setRef(newRef);

--- a/sample/src/index.js
+++ b/sample/src/index.js
@@ -18,7 +18,7 @@ const config = {
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <FirebaseAppProvider firebaseConfig={config} initPerformance>
+    <FirebaseAppProvider firebaseConfig={config}>
       <App />
     </FirebaseAppProvider>
   </StrictMode>


### PR DESCRIPTION
* Drop `initPerformance` #207
* Cleaning up the use/preload types
* Use my good friend `Proxy` to allow access to both the `serviceProps` and the initialized instance without double calling (e.g, `useAuth()()`)
* More checks against double initializing
* Added binding to the initialize call #213 
* `SuspenseWithPerf` now lazy loads performance monitoring and uses the user timing API
* Fixed the CJS build with a better external test #214

## API change:

`use*` functions no longer provide an instance factory, you no longer need to call them again to make calls against the Firebase product.

Developers targeting older browsers will need a Proxy polyfill.

E.g, what was `useAuth()` is now `useAuth` and `useAuth()()` is now `useAuth()`

This allows our API to better match the vanilla JS SDK.

```ts
const Counter = props => {
  const firestore = useFirestore; // was useFirestore()
  const serverIncrement = firestore.FieldValue.increment;
  const ref = firestore().doc('count/counter');
  ...
};
```

```ts
const StaticValue = props => {
  const firestore = useFirestore(); // was useFirestore()()
  const ref = firestore.doc('count/counter');
  ...
};
```

