### PR TITLE
Using our subject/cache to fix the init race I introduced

### DIFF
--- a/reactfire/firebaseApp/index.tsx
+++ b/reactfire/firebaseApp/index.tsx
@@ -6,7 +6,7 @@ export * from './sdk';
 type FirebaseAppContextValue = firebase.app.App;
 
 // INVESTIGATE I don't like magic strings, can we have export this in js-sdk?
-export const DEFAULT_APP_NAME = '[DEFAULT]';
+const DEFAULT_APP_NAME = '[DEFAULT]';
 
 const FirebaseAppContext = React.createContext<
   FirebaseAppContextValue | undefined

--- a/reactfire/firebaseApp/sdk.tsx
+++ b/reactfire/firebaseApp/sdk.tsx
@@ -65,7 +65,7 @@ function proxyComponent(
   let contextualApp: App | undefined;
   const useComponent = () => {
     contextualApp = useFirebaseApp();
-    const sdkSubject = loadSDK(componentName, contextualApp);
+    const sdkSubject = preload(componentName, contextualApp);
     if (!sdkSubject.hasValue) {
       throw sdkSubject.firstEmission;
     }
@@ -105,68 +105,68 @@ export const performance = usePerformance;
 export const remoteConfig = useRemoteConfig;
 export const storage = useStorage;
 
-function preload(
+function preloadFactory(
   componentName: 'auth'
 ): (
   firebaseApp?: App,
   settingsCallback?: (instanceFactory: App['auth']) => any
 ) => Promise<App['auth']>;
-function preload(
+function preloadFactory(
   componentName: 'analytics'
 ): (
   firebaseApp?: App,
   settingsCallback?: (instanceFactory: App['analytics']) => any
 ) => Promise<App['analytics']>;
-function preload(
+function preloadFactory(
   componentName: 'database'
 ): (
   firebaseApp?: App,
   settingsCallback?: (instanceFactory: App['database']) => any
 ) => Promise<App['database']>;
-function preload(
+function preloadFactory(
   componentName: 'firestore'
 ): (
   firebaseApp?: App,
   settingsCallback?: (instanceFactory: App['firestore']) => any
 ) => Promise<App['firestore']>;
-function preload(
+function preloadFactory(
   componentName: 'functions'
 ): (
   firebaseApp?: App,
   settingsCallback?: (instanceFactory: App['functions']) => any
 ) => Promise<App['functions']>;
-function preload(
+function preloadFactory(
   componentName: 'messaging'
 ): (
   firebaseApp?: App,
   settingsCallback?: (instanceFactory: App['messaging']) => any
 ) => Promise<App['messaging']>;
-function preload(
+function preloadFactory(
   componentName: 'performance'
 ): (
   firebaseApp?: App,
   settingsCallback?: (instanceFactory: App['performance']) => any
 ) => Promise<App['performance']>;
-function preload(
+function preloadFactory(
   componentName: 'remoteConfig'
 ): (
   firebaseApp?: App,
   settingsCallback?: (instanceFactory: App['remoteConfig']) => any
 ) => Promise<App['remoteConfig']>;
-function preload(
+function preloadFactory(
   componentName: 'storage'
 ): (
   firebaseApp?: App,
   settingsCallback?: (instanceFactory: App['storage']) => any
 ) => Promise<App['storage']>;
-function preload(componentName: ComponentName) {
+function preloadFactory(componentName: ComponentName) {
   return (
     firebaseApp?: App,
     settingsCallback?: (instanceFactory: FirebaseInstanceFactory) => any
-  ) => loadSDK(componentName, firebaseApp, settingsCallback).toPromise();
+  ) => preload(componentName, firebaseApp, settingsCallback).toPromise();
 }
 
-function loadSDK(
+function preload(
   componentName: ComponentName,
   firebaseApp?: App,
   settingsCallback: (instanceFactory: FirebaseInstanceFactory) => any = () => {}
@@ -193,12 +193,12 @@ function loadSDK(
   );
 }
 
-export const preloadAuth = preload('auth');
-export const preloadAnalytics = preload('analytics');
-export const preloadDatabase = preload('database');
-export const preloadFirestore = preload('firestore');
-export const preloadFunctions = preload('functions');
-export const preloadMessaging = preload('messaging');
-export const preloadPerformance = preload('performance');
-export const preloadRemoteConfig = preload('remoteConfig');
-export const preloadStorage = preload('storage');
+export const preloadAuth = preloadFactory('auth');
+export const preloadAnalytics = preloadFactory('analytics');
+export const preloadDatabase = preloadFactory('database');
+export const preloadFirestore = preloadFactory('firestore');
+export const preloadFunctions = preloadFactory('functions');
+export const preloadMessaging = preloadFactory('messaging');
+export const preloadPerformance = preloadFactory('performance');
+export const preloadRemoteConfig = preloadFactory('remoteConfig');
+export const preloadStorage = preloadFactory('storage');

--- a/reactfire/firebaseApp/sdk.tsx
+++ b/reactfire/firebaseApp/sdk.tsx
@@ -109,55 +109,55 @@ function preloadFactory(
   componentName: 'auth'
 ): (
   firebaseApp?: App,
-  settingsCallback?: (instanceFactory: App['auth']) => any
+  settingsCallback?: (instanceFactory: App['auth']) => void | Promise<any>
 ) => Promise<App['auth']>;
 function preloadFactory(
   componentName: 'analytics'
 ): (
   firebaseApp?: App,
-  settingsCallback?: (instanceFactory: App['analytics']) => any
+  settingsCallback?: (instanceFactory: App['analytics']) => void | Promise<any>
 ) => Promise<App['analytics']>;
 function preloadFactory(
   componentName: 'database'
 ): (
   firebaseApp?: App,
-  settingsCallback?: (instanceFactory: App['database']) => any
+  settingsCallback?: (instanceFactory: App['database']) => void | Promise<any>
 ) => Promise<App['database']>;
 function preloadFactory(
   componentName: 'firestore'
 ): (
   firebaseApp?: App,
-  settingsCallback?: (instanceFactory: App['firestore']) => any
+  settingsCallback?: (instanceFactory: App['firestore']) => void | Promise<any>
 ) => Promise<App['firestore']>;
 function preloadFactory(
   componentName: 'functions'
 ): (
   firebaseApp?: App,
-  settingsCallback?: (instanceFactory: App['functions']) => any
+  settingsCallback?: (instanceFactory: App['functions']) => void | Promise<any>
 ) => Promise<App['functions']>;
 function preloadFactory(
   componentName: 'messaging'
 ): (
   firebaseApp?: App,
-  settingsCallback?: (instanceFactory: App['messaging']) => any
+  settingsCallback?: (instanceFactory: App['messaging']) => void | Promise<any>
 ) => Promise<App['messaging']>;
 function preloadFactory(
   componentName: 'performance'
 ): (
   firebaseApp?: App,
-  settingsCallback?: (instanceFactory: App['performance']) => any
+  settingsCallback?: (instanceFactory: App['performance']) => void | Promise<any>
 ) => Promise<App['performance']>;
 function preloadFactory(
   componentName: 'remoteConfig'
 ): (
   firebaseApp?: App,
-  settingsCallback?: (instanceFactory: App['remoteConfig']) => any
+  settingsCallback?: (instanceFactory: App['remoteConfig']) => void | Promise<any>
 ) => Promise<App['remoteConfig']>;
 function preloadFactory(
   componentName: 'storage'
 ): (
   firebaseApp?: App,
-  settingsCallback?: (instanceFactory: App['storage']) => any
+  settingsCallback?: (instanceFactory: App['storage']) => void | Promise<any>
 ) => Promise<App['storage']>;
 function preloadFactory(componentName: ComponentName) {
   return (

--- a/reactfire/firebaseApp/sdk.tsx
+++ b/reactfire/firebaseApp/sdk.tsx
@@ -63,9 +63,9 @@ function proxyComponent(
   componentName: ComponentName
 ): FirebaseNamespaceComponent {
   let contextualApp: App | undefined;
-  const useComponent = () => {
+  const useComponent = (app?: App) => {
     contextualApp = useFirebaseApp();
-    const sdkSubject = preload(componentName, contextualApp);
+    const sdkSubject = preload(componentName, app || contextualApp);
     if (!sdkSubject.hasValue) {
       throw sdkSubject.firstEmission;
     }
@@ -75,7 +75,7 @@ function proxyComponent(
   return new Proxy(useComponent, {
     get: (target, p) => target()[p],
     apply: (target, _this, args) => {
-      const component = target().bind(_this);
+      const component = target(args[0]).bind(_this);
       // If they don't pass an app, assume the app in context rather than [DEFAULT]
       if (!args[0]) {
         args[0] = contextualApp;

--- a/reactfire/useObservable/index.ts
+++ b/reactfire/useObservable/index.ts
@@ -2,8 +2,22 @@ import * as React from 'react';
 import { Observable } from 'rxjs';
 import { SuspenseSubject } from './SuspenseSubject';
 
+const globalThis = function() {
+  if (typeof self !== 'undefined') { return self; }
+  if (typeof window !== 'undefined') { return window; }
+  if (typeof global !== 'undefined') { return global; }
+  throw new Error('unable to locate global object');
+}();
+
+const PRELOADED_OBSERVABLES = '_reactFirePreloadedObservables';
 const DEFAULT_TIMEOUT = 30_000;
-const preloadedObservables = new Map<string, SuspenseSubject<unknown>>();
+
+// Since we're side-effect free, we need to ensure our observable cache is global
+const preloadedObservables = globalThis[PRELOADED_OBSERVABLES] || new Map<string, SuspenseSubject<unknown>>();
+
+if (!globalThis[PRELOADED_OBSERVABLES]) {
+  globalThis[PRELOADED_OBSERVABLES] = preloadedObservables;
+}
 
 // Starts listening to an Observable.
 // Call this once you know you're going to render a

--- a/sample/package.json
+++ b/sample/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@types/jest": "^24.9.0",
     "firebase": "^7.9.1",
+    "js-levenshtein": "^1.1.6",
     "react": "0.0.0-experimental-5de5b6150",
     "react-dom": "0.0.0-experimental-5de5b6150",
     "react-firebaseui": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7723,6 +7723,11 @@ join-path@^1.1.1:
     url-join "0.0.1"
     valid-url "^1"
 
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
In my prior refactor I introduced two regressions:

1. `useFirestore()`, etc. would not throw a Promise if the init callback from `preloadFirestore` was still awaiting. This is important for `firestore.enablePersistence()` etc. to work correctly.
1. The init callback would not run if you called preload on a second app, since it was checking merely for existence on the namespace. We'll lean on the JS SDK's errors for double initialization.
1. It turns out that since we're side-effect free, webpack "might" copy our module, so our cache needs to be "global". I'm now attaching our preload cache to `globalThis`.