### PR TITLE
Fix useObservable edge case

### DIFF
--- a/reactfire/useObservable/SuspenseSubject.ts
+++ b/reactfire/useObservable/SuspenseSubject.ts
@@ -1,5 +1,5 @@
-import { Observable, Subject, Subscription, Subscriber, empty } from 'rxjs';
-import { tap, share, catchError } from 'rxjs/operators';
+import { empty, Observable, Subject, Subscriber, Subscription } from 'rxjs';
+import { catchError, shareReplay, tap } from 'rxjs/operators';
 
 export class SuspenseSubject<T> extends Subject<T> {
   private _value: T | undefined;
@@ -14,9 +14,7 @@ export class SuspenseSubject<T> extends Subject<T> {
 
   constructor(innerObservable: Observable<T>, private _timeoutWindow: number) {
     super();
-    this._firstEmission = new Promise<void>(
-      resolve => (this._resolveFirstEmission = resolve)
-    );
+    this._firstEmission = new Promise<void>(resolve => (this._resolveFirstEmission = resolve));
     this._innerObservable = innerObservable.pipe(
       tap(
         v => {
@@ -30,7 +28,7 @@ export class SuspenseSubject<T> extends Subject<T> {
         }
       ),
       catchError(() => empty()),
-      share()
+      shareReplay(1)
     );
     // warm up the observable
     this._warmupSubscription = this._innerObservable.subscribe();
@@ -75,9 +73,7 @@ export class SuspenseSubject<T> extends Subject<T> {
     this._hasValue = false;
     this._value = undefined;
     this._error = undefined;
-    this._firstEmission = new Promise<void>(
-      resolve => (this._resolveFirstEmission = resolve)
-    );
+    this._firstEmission = new Promise<void>(resolve => (this._resolveFirstEmission = resolve));
   }
 
   _subscribe(subscriber: Subscriber<T>): Subscription {

--- a/reactfire/useObservable/useObservable.test.tsx
+++ b/reactfire/useObservable/useObservable.test.tsx
@@ -35,9 +35,7 @@ describe('useObservable', () => {
     const observableVal = "y'all";
     const observable$ = new Subject<any>();
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useObservable(observable$, 'test-2', startVal)
-    );
+    const { result, waitForNextUpdate } = renderHook(() => useObservable(observable$, 'test-2', startVal));
 
     expect(result.current).toEqual(startVal);
 
@@ -118,9 +116,7 @@ describe('useObservable', () => {
     const actualComponentId = 'actual-component';
     const fallbackComponentId = 'fallback-component';
 
-    const FallbackComponent = () => (
-      <h1 data-testid={fallbackComponentId}>Fallback</h1>
-    );
+    const FallbackComponent = () => <h1 data-testid={fallbackComponentId}>Fallback</h1>;
 
     const Component = () => {
       const val = useObservable(observable$, 'test-suspense');
@@ -142,9 +138,7 @@ describe('useObservable', () => {
 
     // make sure Suspense correctly renders its child after the observable emits a value
     expect(getByTestId(actualComponentId)).toBeInTheDocument();
-    expect(getByTestId(actualComponentId)).toHaveTextContent(
-      observableFinalVal
-    );
+    expect(getByTestId(actualComponentId)).toHaveTextContent(observableFinalVal);
     expect(queryByTestId(fallbackComponentId)).toBeNull();
   });
 
@@ -153,9 +147,7 @@ describe('useObservable', () => {
     const values = ['a', 'b', 'c'];
     const observable$ = new Subject();
 
-    const { result } = renderHook(() =>
-      useObservable(observable$, 'test-changes', startVal)
-    );
+    const { result } = renderHook(() => useObservable(observable$, 'test-changes', startVal));
 
     expect(result.current).toEqual(startVal);
 
@@ -182,16 +174,12 @@ describe('useObservable', () => {
       return (
         <React.Suspense fallback="loading">
           <ObservableConsumer data-testid={firstComponentId} />
-          {renderSecondComponent ? (
-            <ObservableConsumer data-testid={secondComponentId} />
-          ) : null}
+          {renderSecondComponent ? <ObservableConsumer data-testid={secondComponentId} /> : null}
         </React.Suspense>
       );
     };
 
-    const { getByTestId, rerender } = render(
-      <Component renderSecondComponent={false} />
-    );
+    const { getByTestId, rerender } = render(<Component renderSecondComponent={false} />);
 
     // emit one value to the first component (second one isn't rendered yet)
     act(() => observable$.next(values[0]));


### PR DESCRIPTION
If a component changed the observable it passed to `useObservable`, `useObservable` wouldn't emit the new observable's first value.

This happened for 2 reasons:

1. React didn't reset `useObservable`'s `latest` value (by calling the function passed to `useState`). This is where `useObservable` usually gets the first value.
1. Because `useObservable` subscribed to the new observable in a `useEffect` call, that subscribe happens async and often *after* the observable emits its first value.

Changing `share` to `shareReplay` in `SuspenseSubject` causes the new observable to emit when the subscribe happens in `useObservable`, fixing this bug.