### PR TITLE
Use observable value directly in useObservable

### DIFF
--- a/reactfire/useObservable/index.ts
+++ b/reactfire/useObservable/index.ts
@@ -33,15 +33,15 @@ export function useObservable<T>(source: Observable<T | any>, observableId: stri
   if (!observable.hasValue && !startWithValue) {
     throw observable.firstEmission;
   }
-  const [latest, setValue] = React.useState(() => (observable.hasValue ? observable.value : startWithValue));
+  const [, update] = React.useState(() => (observable.hasValue ? observable.value : startWithValue));
   React.useEffect(() => {
     const subscription = observable.subscribe(
-      v => setValue(() => v),
+      v => update(() => v),
       e => {
         throw e;
       }
     );
     return () => subscription.unsubscribe();
   }, deps);
-  return latest;
+  return observable.value;
 }


### PR DESCRIPTION
Today I came across an interesting problem with `useObservable`.

Imagine the following situation.

- User creates a custom observable using a memoized `combineLatest`. I pass this observable to `useObservable`.
- Later on, app parameters change and a new memoized observable is created.

Now, there's an interesting bug going on where for _one render_ between the previous and new state I see an intermediate result from `useObservable` where it's using the new observable but the output value is the last value seen from the old observable.

The cause seems to be the use of `setState` on line 36: when the observable is changed, the state still contains the value of the old observable, and won't update until after the render is completed and the `useEffect` subscription runs.

So there's one render where the invariants in my app are broken and I see exceptions / warnings.

A fix seems to be to return `observable.value` directly instead of the stored state, because that's always up to date. The `useState` is still necessary to cause updates when the output changes, but we ignore the state value itself.