### PR TITLE
Support Firebase 8.0 ESM Module

### DIFF
--- a/reactfire/firebaseApp/index.tsx
+++ b/reactfire/firebaseApp/index.tsx
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase/app';
+import firebase from 'firebase/app';
 import * as React from 'react';
 
 type FirebaseAppContextValue = firebase.app.App;


### PR DESCRIPTION
https://firebase.google.com/support/release-notes/js#version_800_-_october_26_2020

https://stackoverflow.com/questions/64545862/upgrade-to-firebase-js-8-0-0-attempted-import-error-app-is-not-exported-from


I don't think this is a breaking change in any way other than it will unbroken by this?

The Firebase changelog does list some changes that might be good to add at a later date, but for speed, just fixing this error would be enough in the short term?