### PR TITLE
Reduce "rules of hooks" lint error to warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "tsdx build",
     "test:tsdx": "tsdx test",
     "test": "firebase emulators:exec --only firestore,database,auth --project rxfire-525a3 \"tsdx test --detectOpenHandles --forceExit\"",
-    "lint": "tsdx lint",
+    "lint": "tsdx lint src test",
     "prepare": "tsdx build",
     "size": "size-limit",
     "analyze": "size-limit --why",
@@ -27,7 +27,12 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "tsdx lint"
+      "pre-commit": "yarn lint"
+    }
+  },
+  "eslint": {
+    "rules": {
+      "react-hooks/rules-of-hooks": "warn"
     }
   },
   "prettier": {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Our precommit hook fails because we fail the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html) in some places of ReactFire. This PR reduces that fail to a warning so we can still commit changes while we work on an api update that allows us to fully comply with the Rules of Hooks.

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
