### PR TITLE
Reference docs improvements

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,42 @@
+name: Check if Reference Docs need to be regenerated
+
+on:
+  pull_request
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+      - name: node_modules cache
+        id: node_modules_cache
+        uses: actions/cache@v2
+        with:
+          path: ./node_modules
+          key: ${{ runner.os }}-14-node_modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-14-node_modules-
+      - name: Yarn offline cache
+        if: steps.node_modules_cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm-packages-offline-cache
+          key: yarn-offline-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: yarn-offline
+      - name: Install deps
+        if: steps.node_modules_cache.outputs.cache-hit != 'true'
+        run: |
+          yarn config set yarn-offline-mirror ~/.npm-packages-offline-cache
+          yarn config set yarn-offline-mirror-pruning true
+          yarn install --frozen-lockfile --prefer-offline
+      - name: Generate reference docs
+        run: yarn docs
+      - name: Check for diff
+        run: git diff --exit-code -- 'docs/reference***.md'
+

--- a/docs/reference/classes/_suspensesubject_.suspensesubject.md
+++ b/docs/reference/classes/_suspensesubject_.suspensesubject.md
@@ -83,7 +83,7 @@ Name |
 
 *Overrides void*
 
-*Defined in [src/SuspenseSubject.ts:16](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L16)*
+*Defined in [src/SuspenseSubject.ts:16](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L16)*
 
 #### Parameters:
 
@@ -100,7 +100,7 @@ Name | Type |
 
 • `Private` **\_error**: any = undefined
 
-*Defined in [src/SuspenseSubject.ts:9](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L9)*
+*Defined in [src/SuspenseSubject.ts:9](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L9)*
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 • `Private` **\_firstEmission**: Promise\<void>
 
-*Defined in [src/SuspenseSubject.ts:8](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L8)*
+*Defined in [src/SuspenseSubject.ts:8](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L8)*
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 • `Private` **\_hasValue**: boolean = false
 
-*Defined in [src/SuspenseSubject.ts:6](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L6)*
+*Defined in [src/SuspenseSubject.ts:6](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L6)*
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 • `Private` **\_innerObservable**: Observable\<T>
 
-*Defined in [src/SuspenseSubject.ts:10](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L10)*
+*Defined in [src/SuspenseSubject.ts:10](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L10)*
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 • `Private` **\_innerSubscriber**: Subscription
 
-*Defined in [src/SuspenseSubject.ts:14](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L14)*
+*Defined in [src/SuspenseSubject.ts:14](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L14)*
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 • `Private` **\_resolveFirstEmission**: () => void
 
-*Defined in [src/SuspenseSubject.ts:16](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L16)*
+*Defined in [src/SuspenseSubject.ts:16](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L16)*
 
 ___
 
@@ -160,7 +160,7 @@ ___
 
 • `Private` **\_timeoutHandler**: Timeout
 
-*Defined in [src/SuspenseSubject.ts:7](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L7)*
+*Defined in [src/SuspenseSubject.ts:7](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L7)*
 
 ___
 
@@ -168,7 +168,7 @@ ___
 
 • `Private` **\_timeoutWindow**: number
 
-*Defined in [src/SuspenseSubject.ts:18](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L18)*
+*Defined in [src/SuspenseSubject.ts:18](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L18)*
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 • `Private` **\_value**: T \| undefined
 
-*Defined in [src/SuspenseSubject.ts:5](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L5)*
+*Defined in [src/SuspenseSubject.ts:5](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L5)*
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 • `Private` **\_warmupSubscription**: Subscription
 
-*Defined in [src/SuspenseSubject.ts:11](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L11)*
+*Defined in [src/SuspenseSubject.ts:11](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L11)*
 
 ___
 
@@ -310,7 +310,7 @@ ___
 
 • get **firstEmission**(): Promise\<void>
 
-*Defined in [src/SuspenseSubject.ts:61](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L61)*
+*Defined in [src/SuspenseSubject.ts:61](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L61)*
 
 **Returns:** Promise\<void>
 
@@ -320,7 +320,7 @@ ___
 
 • get **hasValue**(): boolean
 
-*Defined in [src/SuspenseSubject.ts:44](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L44)*
+*Defined in [src/SuspenseSubject.ts:44](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L44)*
 
 **Returns:** boolean
 
@@ -330,7 +330,7 @@ ___
 
 • get **ourError**(): any
 
-*Defined in [src/SuspenseSubject.ts:90](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L90)*
+*Defined in [src/SuspenseSubject.ts:90](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L90)*
 
 **Returns:** any
 
@@ -340,7 +340,7 @@ ___
 
 • get **value**(): T \| undefined
 
-*Defined in [src/SuspenseSubject.ts:51](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L51)*
+*Defined in [src/SuspenseSubject.ts:51](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L51)*
 
 **Returns:** T \| undefined
 
@@ -350,7 +350,7 @@ ___
 
 ▸ `Private`**_next**(`value`: T): void
 
-*Defined in [src/SuspenseSubject.ts:65](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L65)*
+*Defined in [src/SuspenseSubject.ts:65](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L65)*
 
 #### Parameters:
 
@@ -366,7 +366,7 @@ ___
 
 ▸ `Private`**_reset**(): void
 
-*Defined in [src/SuspenseSubject.ts:71](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L71)*
+*Defined in [src/SuspenseSubject.ts:71](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L71)*
 
 **Returns:** void
 
@@ -378,7 +378,7 @@ ___
 
 *Overrides void*
 
-*Defined in [src/SuspenseSubject.ts:82](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/SuspenseSubject.ts#L82)*
+*Defined in [src/SuspenseSubject.ts:82](https://github.com/FirebaseExtended/reactfire/blob/master/src/SuspenseSubject.ts#L82)*
 
 #### Parameters:
 

--- a/docs/reference/interfaces/_auth_.authcheckprops.md
+++ b/docs/reference/interfaces/_auth_.authcheckprops.md
@@ -21,9 +21,9 @@
 
 ### auth
 
-• `Optional` **auth**: auth.Auth
+• `Optional` **auth**: firebase.auth.Auth
 
-*Defined in [src/auth.tsx:53](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L53)*
+*Defined in [src/auth.tsx:61](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L61)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 •  **children**: React.ReactNode
 
-*Defined in [src/auth.tsx:55](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L55)*
+*Defined in [src/auth.tsx:63](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L63)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 •  **fallback**: React.ReactNode
 
-*Defined in [src/auth.tsx:54](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L54)*
+*Defined in [src/auth.tsx:62](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L62)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 • `Optional` **requiredClaims**: Object
 
-*Defined in [src/auth.tsx:56](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L56)*
+*Defined in [src/auth.tsx:64](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L64)*

--- a/docs/reference/interfaces/_auth_.claimscheckprops.md
+++ b/docs/reference/interfaces/_auth_.claimscheckprops.md
@@ -23,7 +23,7 @@
 
 •  **children**: React.ReactNode
 
-*Defined in [src/auth.tsx:62](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L62)*
+*Defined in [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L70)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 •  **fallback**: React.ReactNode
 
-*Defined in [src/auth.tsx:61](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L61)*
+*Defined in [src/auth.tsx:69](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L69)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **requiredClaims**: undefined \| { [key:string]: any;  }
 
-*Defined in [src/auth.tsx:63](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L63)*
+*Defined in [src/auth.tsx:71](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L71)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 •  **user**: User
 
-*Defined in [src/auth.tsx:60](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L60)*
+*Defined in [src/auth.tsx:68](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L68)*

--- a/docs/reference/interfaces/_index_.reactfireoptions.md
+++ b/docs/reference/interfaces/_index_.reactfireoptions.md
@@ -28,7 +28,7 @@ Name | Default |
 
 • `Optional` **idField**: undefined \| string
 
-*Defined in [src/index.ts:11](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/index.ts#L11)*
+*Defined in [src/index.ts:11](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L11)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 • `Optional` **initialData**: T \| any
 
-*Defined in [src/index.ts:12](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/index.ts#L12)*
+*Defined in [src/index.ts:12](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L12)*
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 • `Optional` **suspense**: undefined \| false \| true
 
-*Defined in [src/index.ts:13](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/index.ts#L13)*
+*Defined in [src/index.ts:13](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L13)*

--- a/docs/reference/interfaces/_performance_.suspenseperfprops.md
+++ b/docs/reference/interfaces/_performance_.suspenseperfprops.md
@@ -23,7 +23,7 @@
 
 •  **children**: React.ReactNode
 
-*Defined in [src/performance.tsx:6](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/performance.tsx#L6)*
+*Defined in [src/performance.tsx:6](https://github.com/FirebaseExtended/reactfire/blob/master/src/performance.tsx#L6)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 •  **fallback**: React.ReactNode
 
-*Defined in [src/performance.tsx:8](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/performance.tsx#L8)*
+*Defined in [src/performance.tsx:8](https://github.com/FirebaseExtended/reactfire/blob/master/src/performance.tsx#L8)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **firePerf**: undefined \| Performance
 
-*Defined in [src/performance.tsx:9](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/performance.tsx#L9)*
+*Defined in [src/performance.tsx:9](https://github.com/FirebaseExtended/reactfire/blob/master/src/performance.tsx#L9)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 •  **traceId**: string
 
-*Defined in [src/performance.tsx:7](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/performance.tsx#L7)*
+*Defined in [src/performance.tsx:7](https://github.com/FirebaseExtended/reactfire/blob/master/src/performance.tsx#L7)*

--- a/docs/reference/interfaces/_remote_config_getvalue_.parametersettings.md
+++ b/docs/reference/interfaces/_remote_config_getvalue_.parametersettings.md
@@ -28,7 +28,7 @@ Name |
 
 •  **getter**: (key: string) => T
 
-*Defined in [src/remote-config/getValue.tsx:13](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/getValue.tsx#L13)*
+*Defined in [src/remote-config/getValue.tsx:13](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/getValue.tsx#L13)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 •  **key**: string
 
-*Defined in [src/remote-config/getValue.tsx:12](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/getValue.tsx#L12)*
+*Defined in [src/remote-config/getValue.tsx:12](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/getValue.tsx#L12)*
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 •  **remoteConfig**: RemoteConfig
 
-*Defined in [src/remote-config/getValue.tsx:11](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/getValue.tsx#L11)*
+*Defined in [src/remote-config/getValue.tsx:11](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/getValue.tsx#L11)*

--- a/docs/reference/interfaces/_remote_config_index_.remoteconfigwithprivate.md
+++ b/docs/reference/interfaces/_remote_config_index_.remoteconfigwithprivate.md
@@ -39,7 +39,7 @@
 
 • `Optional` **\_storage**: undefined \| { appName: string  }
 
-*Defined in [src/remote-config/index.tsx:12](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/index.tsx#L12)*
+*Defined in [src/remote-config/index.tsx:12](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/index.tsx#L12)*
 
 ___
 

--- a/docs/reference/interfaces/_useobservable_.observablestatus.md
+++ b/docs/reference/interfaces/_useobservable_.observablestatus.md
@@ -31,7 +31,7 @@ Name |
 
 •  **data**: T
 
-*Defined in [src/useObservable.ts:36](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/useObservable.ts#L36)*
+*Defined in [src/useObservable.ts:36](https://github.com/FirebaseExtended/reactfire/blob/master/src/useObservable.ts#L36)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 •  **error**: Error \| undefined
 
-*Defined in [src/useObservable.ts:37](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/useObservable.ts#L37)*
+*Defined in [src/useObservable.ts:37](https://github.com/FirebaseExtended/reactfire/blob/master/src/useObservable.ts#L37)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 •  **firstValuePromise**: Promise\<void>
 
-*Defined in [src/useObservable.ts:38](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/useObservable.ts#L38)*
+*Defined in [src/useObservable.ts:38](https://github.com/FirebaseExtended/reactfire/blob/master/src/useObservable.ts#L38)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 •  **hasEmitted**: boolean
 
-*Defined in [src/useObservable.ts:34](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/useObservable.ts#L34)*
+*Defined in [src/useObservable.ts:34](https://github.com/FirebaseExtended/reactfire/blob/master/src/useObservable.ts#L34)*
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 •  **isComplete**: boolean
 
-*Defined in [src/useObservable.ts:35](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/useObservable.ts#L35)*
+*Defined in [src/useObservable.ts:35](https://github.com/FirebaseExtended/reactfire/blob/master/src/useObservable.ts#L35)*
 
 ___
 
@@ -71,4 +71,4 @@ ___
 
 •  **status**: \"loading\" \| \"error\" \| \"success\"
 
-*Defined in [src/useObservable.ts:30](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/useObservable.ts#L30)*
+*Defined in [src/useObservable.ts:30](https://github.com/FirebaseExtended/reactfire/blob/master/src/useObservable.ts#L30)*

--- a/docs/reference/modules/_auth_.md
+++ b/docs/reference/modules/_auth_.md
@@ -25,7 +25,7 @@
 
 ▸ **AuthCheck**(`__namedParameters`: { auth: undefined \| Auth ; children: ReactNode ; fallback: ReactNode ; requiredClaims: undefined \| Object  }): Element
 
-*Defined in [src/auth.tsx:89](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L89)*
+*Defined in [src/auth.tsx:97](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L97)*
 
 #### Parameters:
 
@@ -41,7 +41,7 @@ ___
 
 ▸ **ClaimsCheck**(`__namedParameters`: { children: ReactNode ; fallback: ReactNode ; requiredClaims: undefined \| { [key:string]: any;  } ; user: User  }): Element
 
-*Defined in [src/auth.tsx:66](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L66)*
+*Defined in [src/auth.tsx:74](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L74)*
 
 #### Parameters:
 
@@ -57,7 +57,7 @@ ___
 
 ▸ **preloadUser**(`options?`: undefined \| { firebaseApp?: firebase.app.App  }): Promise\<User>
 
-*Defined in [src/auth.tsx:8](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L8)*
+*Defined in [src/auth.tsx:8](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L8)*
 
 #### Parameters:
 
@@ -73,7 +73,7 @@ ___
 
 ▸ **useIdTokenResult**(`user`: User, `forceRefresh?`: boolean, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<IdTokenResult>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<IdTokenResult>
 
-*Defined in [src/auth.tsx:37](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L37)*
+*Defined in [src/auth.tsx:45](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L45)*
 
 #### Parameters:
 
@@ -89,9 +89,9 @@ ___
 
 ### useUser
 
-▸ **useUser**\<T>(`auth?`: auth.Auth, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<User>
+▸ **useUser**\<T>(`auth?`: firebase.auth.Auth, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<User>
 
-*Defined in [src/auth.tsx:24](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/auth.tsx#L24)*
+*Defined in [src/auth.tsx:24](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L24)*
 
 Subscribe to Firebase auth state changes, including token refresh
 
@@ -105,7 +105,7 @@ Name | Default |
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`auth?` | auth.Auth | the [firebase.auth](https://firebase.google.com/docs/reference/js/firebase.auth) object |
+`auth?` | firebase.auth.Auth | the [firebase.auth](https://firebase.google.com/docs/reference/js/firebase.auth) object |
 `options?` | [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T> |   |
 
 **Returns:** [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<User>

--- a/docs/reference/modules/_database_.md
+++ b/docs/reference/modules/_database_.md
@@ -26,7 +26,7 @@
 
 • `Const` **cachedQueries**: Array\<Query> = ((globalThis as any) as ReactFireGlobals).\_reactFireDatabaseCachedQueries \|\| []
 
-*Defined in [src/database.tsx:9](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/database.tsx#L9)*
+*Defined in [src/database.tsx:9](https://github.com/FirebaseExtended/reactfire/blob/master/src/database.tsx#L9)*
 
 ## Functions
 
@@ -34,7 +34,7 @@
 
 ▸ **changeToData**(`change`: QueryChange, `keyField?`: undefined \| string): object
 
-*Defined in [src/database.tsx:44](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/database.tsx#L44)*
+*Defined in [src/database.tsx:44](https://github.com/FirebaseExtended/reactfire/blob/master/src/database.tsx#L44)*
 
 #### Parameters:
 
@@ -51,7 +51,7 @@ ___
 
 ▸ **getUniqueIdForDatabaseQuery**(`query`: Query): number
 
-*Defined in [src/database.tsx:15](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/database.tsx#L15)*
+*Defined in [src/database.tsx:15](https://github.com/FirebaseExtended/reactfire/blob/master/src/database.tsx#L15)*
 
 #### Parameters:
 
@@ -67,7 +67,7 @@ ___
 
 ▸ **objectVal**\<T>(`query`: Query, `keyField?`: undefined \| string): Observable\<T>
 
-*Defined in [src/database.tsx:40](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/database.tsx#L40)*
+*Defined in [src/database.tsx:40](https://github.com/FirebaseExtended/reactfire/blob/master/src/database.tsx#L40)*
 
 #### Type parameters:
 
@@ -90,7 +90,7 @@ ___
 
 ▸ **useDatabaseList**\<T>(`ref`: Reference \| Query, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T[]>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<QueryChange[] \| T[]>
 
-*Defined in [src/database.tsx:73](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/database.tsx#L73)*
+*Defined in [src/database.tsx:73](https://github.com/FirebaseExtended/reactfire/blob/master/src/database.tsx#L73)*
 
 Subscribe to a Realtime Database list
 
@@ -115,7 +115,7 @@ ___
 
 ▸ **useDatabaseListData**\<T>(`ref`: Reference \| Query, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T[]>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<T[]>
 
-*Defined in [src/database.tsx:83](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/database.tsx#L83)*
+*Defined in [src/database.tsx:83](https://github.com/FirebaseExtended/reactfire/blob/master/src/database.tsx#L83)*
 
 #### Type parameters:
 
@@ -138,7 +138,7 @@ ___
 
 ▸ **useDatabaseObject**\<T>(`ref`: Reference, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<QueryChange \| T>
 
-*Defined in [src/database.tsx:29](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/database.tsx#L29)*
+*Defined in [src/database.tsx:29](https://github.com/FirebaseExtended/reactfire/blob/master/src/database.tsx#L29)*
 
 Subscribe to a Realtime Database object
 
@@ -163,7 +163,7 @@ ___
 
 ▸ **useDatabaseObjectData**\<T>(`ref`: Reference, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<T>
 
-*Defined in [src/database.tsx:59](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/database.tsx#L59)*
+*Defined in [src/database.tsx:59](https://github.com/FirebaseExtended/reactfire/blob/master/src/database.tsx#L59)*
 
 #### Type parameters:
 

--- a/docs/reference/modules/_firebaseapp_.md
+++ b/docs/reference/modules/_firebaseapp_.md
@@ -231,7 +231,7 @@ Re-exports: [useStorage](_sdk_.md#usestorage)
 
 Ƭ  **FirebaseAppContextValue**: App
 
-*Defined in [src/firebaseApp.tsx:6](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firebaseApp.tsx#L6)*
+*Defined in [src/firebaseApp.tsx:6](https://github.com/FirebaseExtended/reactfire/blob/master/src/firebaseApp.tsx#L6)*
 
 ___
 
@@ -239,7 +239,7 @@ ___
 
 Ƭ  **Props**: { appName?: undefined \| string ; firebaseApp?: firebase.app.App ; firebaseConfig?: Object ; suspense?: undefined \| false \| true  }
 
-*Defined in [src/firebaseApp.tsx:15](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firebaseApp.tsx#L15)*
+*Defined in [src/firebaseApp.tsx:15](https://github.com/FirebaseExtended/reactfire/blob/master/src/firebaseApp.tsx#L15)*
 
 #### Type declaration:
 
@@ -256,7 +256,7 @@ Name | Type |
 
 • `Const` **DEFAULT\_APP\_NAME**: \"[DEFAULT]\" = "[DEFAULT]"
 
-*Defined in [src/firebaseApp.tsx:9](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firebaseApp.tsx#L9)*
+*Defined in [src/firebaseApp.tsx:9](https://github.com/FirebaseExtended/reactfire/blob/master/src/firebaseApp.tsx#L9)*
 
 ___
 
@@ -264,7 +264,7 @@ ___
 
 • `Const` **FirebaseAppContext**: Context\<undefined \| App> = React.createContext\<FirebaseAppContextValue \| undefined>(undefined)
 
-*Defined in [src/firebaseApp.tsx:11](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firebaseApp.tsx#L11)*
+*Defined in [src/firebaseApp.tsx:11](https://github.com/FirebaseExtended/reactfire/blob/master/src/firebaseApp.tsx#L11)*
 
 ___
 
@@ -272,7 +272,7 @@ ___
 
 • `Const` **SuspenseEnabledContext**: Context\<boolean> = React.createContext\<boolean>(false)
 
-*Defined in [src/firebaseApp.tsx:13](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firebaseApp.tsx#L13)*
+*Defined in [src/firebaseApp.tsx:13](https://github.com/FirebaseExtended/reactfire/blob/master/src/firebaseApp.tsx#L13)*
 
 ___
 
@@ -280,7 +280,7 @@ ___
 
 • `Const` **version**: any = \_\_REACTFIRE\_VERSION\_\_
 
-*Defined in [src/firebaseApp.tsx:23](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firebaseApp.tsx#L23)*
+*Defined in [src/firebaseApp.tsx:23](https://github.com/FirebaseExtended/reactfire/blob/master/src/firebaseApp.tsx#L23)*
 
 ## Functions
 
@@ -288,7 +288,7 @@ ___
 
 ▸ **FirebaseAppProvider**(`props`: [Props](_firebaseapp_.md#props) & { [key:string]: unknown;  }): Element
 
-*Defined in [src/firebaseApp.tsx:27](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firebaseApp.tsx#L27)*
+*Defined in [src/firebaseApp.tsx:27](https://github.com/FirebaseExtended/reactfire/blob/master/src/firebaseApp.tsx#L27)*
 
 #### Parameters:
 
@@ -304,7 +304,7 @@ ___
 
 ▸ `Const`**shallowEq**(`a`: { [key:string]: any;  }, `b`: { [key:string]: any;  }): boolean
 
-*Defined in [src/firebaseApp.tsx:25](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firebaseApp.tsx#L25)*
+*Defined in [src/firebaseApp.tsx:25](https://github.com/FirebaseExtended/reactfire/blob/master/src/firebaseApp.tsx#L25)*
 
 #### Parameters:
 
@@ -321,7 +321,7 @@ ___
 
 ▸ **useFirebaseApp**(): App
 
-*Defined in [src/firebaseApp.tsx:82](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firebaseApp.tsx#L82)*
+*Defined in [src/firebaseApp.tsx:82](https://github.com/FirebaseExtended/reactfire/blob/master/src/firebaseApp.tsx#L82)*
 
 **Returns:** App
 
@@ -331,7 +331,7 @@ ___
 
 ▸ **useIsSuspenseEnabled**(): boolean
 
-*Defined in [src/firebaseApp.tsx:64](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firebaseApp.tsx#L64)*
+*Defined in [src/firebaseApp.tsx:64](https://github.com/FirebaseExtended/reactfire/blob/master/src/firebaseApp.tsx#L64)*
 
 **Returns:** boolean
 
@@ -341,7 +341,7 @@ ___
 
 ▸ **useSuspenseEnabledFromConfigAndContext**(`suspenseFromConfig?`: undefined \| false \| true): boolean
 
-*Defined in [src/firebaseApp.tsx:71](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firebaseApp.tsx#L71)*
+*Defined in [src/firebaseApp.tsx:71](https://github.com/FirebaseExtended/reactfire/blob/master/src/firebaseApp.tsx#L71)*
 
 #### Parameters:
 

--- a/docs/reference/modules/_firestore_.md
+++ b/docs/reference/modules/_firestore_.md
@@ -27,7 +27,7 @@
 
 • `Const` **cachedQueries**: Array\<Query> = ((globalThis as any) as ReactFireGlobals).\_reactFireFirestoreQueryCache \|\| []
 
-*Defined in [src/firestore.tsx:9](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firestore.tsx#L9)*
+*Defined in [src/firestore.tsx:9](https://github.com/FirebaseExtended/reactfire/blob/master/src/firestore.tsx#L9)*
 
 ## Functions
 
@@ -35,7 +35,7 @@
 
 ▸ **getUniqueIdForFirestoreQuery**(`query`: Query): number
 
-*Defined in [src/firestore.tsx:15](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firestore.tsx#L15)*
+*Defined in [src/firestore.tsx:15](https://github.com/FirebaseExtended/reactfire/blob/master/src/firestore.tsx#L15)*
 
 #### Parameters:
 
@@ -49,9 +49,9 @@ ___
 
 ### preloadFirestoreDoc
 
-▸ **preloadFirestoreDoc**(`refProvider`: (firestore: Firestore) => DocumentReference, `options?`: undefined \| { firebaseApp?: firebase.app.App  }): Promise\<[SuspenseSubject](../classes/_suspensesubject_.suspensesubject.md)\<DocumentSnapshot\<DocumentData>>>
+▸ **preloadFirestoreDoc**(`refProvider`: (firestore: Firestore) => DocumentReference, `options?`: undefined \| { firebaseApp?: firebase.app.App  }): Promise\<[SuspenseSubject](../classes/_suspensesubject_.suspensesubject.md)\<DocumentSnapshot>>
 
-*Defined in [src/firestore.tsx:29](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firestore.tsx#L29)*
+*Defined in [src/firestore.tsx:29](https://github.com/FirebaseExtended/reactfire/blob/master/src/firestore.tsx#L29)*
 
 #### Parameters:
 
@@ -60,7 +60,7 @@ Name | Type |
 `refProvider` | (firestore: Firestore) => DocumentReference |
 `options?` | undefined \| { firebaseApp?: firebase.app.App  } |
 
-**Returns:** Promise\<[SuspenseSubject](../classes/_suspensesubject_.suspensesubject.md)\<DocumentSnapshot\<DocumentData>>>
+**Returns:** Promise\<[SuspenseSubject](../classes/_suspensesubject_.suspensesubject.md)\<DocumentSnapshot>>
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 ▸ **useFirestoreCollection**\<T>(`query`: Query, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T[]>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<T *extends* {} ? T[] : QuerySnapshot>
 
-*Defined in [src/firestore.tsx:110](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firestore.tsx#L110)*
+*Defined in [src/firestore.tsx:110](https://github.com/FirebaseExtended/reactfire/blob/master/src/firestore.tsx#L110)*
 
 Subscribe to a Firestore collection
 
@@ -93,7 +93,7 @@ ___
 
 ▸ **useFirestoreCollectionData**\<T>(`query`: Query, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T[]>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<T[]>
 
-*Defined in [src/firestore.tsx:126](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firestore.tsx#L126)*
+*Defined in [src/firestore.tsx:126](https://github.com/FirebaseExtended/reactfire/blob/master/src/firestore.tsx#L126)*
 
 Subscribe to a Firestore collection and unwrap the snapshot.
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **useFirestoreDoc**\<T>(`ref`: DocumentReference, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<T *extends* {} ? T : DocumentSnapshot>
 
-*Defined in [src/firestore.tsx:48](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firestore.tsx#L48)*
+*Defined in [src/firestore.tsx:48](https://github.com/FirebaseExtended/reactfire/blob/master/src/firestore.tsx#L48)*
 
 Suscribe to Firestore Document changes
 
@@ -143,7 +143,7 @@ ___
 
 ▸ **useFirestoreDocData**\<T>(`ref`: DocumentReference, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<T>
 
-*Defined in [src/firestore.tsx:80](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firestore.tsx#L80)*
+*Defined in [src/firestore.tsx:80](https://github.com/FirebaseExtended/reactfire/blob/master/src/firestore.tsx#L80)*
 
 Suscribe to Firestore Document changes
 
@@ -168,7 +168,7 @@ ___
 
 ▸ **useFirestoreDocDataOnce**\<T>(`ref`: DocumentReference, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<T>
 
-*Defined in [src/firestore.tsx:95](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firestore.tsx#L95)*
+*Defined in [src/firestore.tsx:95](https://github.com/FirebaseExtended/reactfire/blob/master/src/firestore.tsx#L95)*
 
 Get a firestore document and don't subscribe to changes
 
@@ -193,7 +193,7 @@ ___
 
 ▸ **useFirestoreDocOnce**\<T>(`ref`: DocumentReference, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<T *extends* {} ? T : DocumentSnapshot>
 
-*Defined in [src/firestore.tsx:64](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/firestore.tsx#L64)*
+*Defined in [src/firestore.tsx:64](https://github.com/FirebaseExtended/reactfire/blob/master/src/firestore.tsx#L64)*
 
 Get a firestore document and don't subscribe to changes
 

--- a/docs/reference/modules/_index_.md
+++ b/docs/reference/modules/_index_.md
@@ -477,7 +477,7 @@ Re-exports: [version](_firebaseapp_.md#version)
 
 Ƭ  **ReactFireGlobals**: { _reactFireDatabaseCachedQueries: Array\<Query> ; _reactFireFirestoreQueryCache: Array\<Query> ; _reactFirePreloadedObservables: Map\<string, [SuspenseSubject](../classes/_suspensesubject_.suspensesubject.md)\<any>>  }
 
-*Defined in [src/index.ts:4](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/index.ts#L4)*
+*Defined in [src/index.ts:4](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L4)*
 
 #### Type declaration:
 
@@ -493,7 +493,7 @@ Name | Type |
 
 ▸ **checkIdField**(`options`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)): any
 
-*Defined in [src/index.ts:29](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/index.ts#L29)*
+*Defined in [src/index.ts:29](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L29)*
 
 #### Parameters:
 
@@ -509,7 +509,7 @@ ___
 
 ▸ **checkOptions**(`options`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md), `field`: string): any
 
-*Defined in [src/index.ts:16](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/index.ts#L16)*
+*Defined in [src/index.ts:16](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L16)*
 
 #### Parameters:
 
@@ -526,7 +526,7 @@ ___
 
 ▸ **checkinitialData**(`options`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)): any
 
-*Defined in [src/index.ts:25](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/index.ts#L25)*
+*Defined in [src/index.ts:25](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L25)*
 
 #### Parameters:
 

--- a/docs/reference/modules/_performance_.md
+++ b/docs/reference/modules/_performance_.md
@@ -20,7 +20,7 @@
 
 ▸ **SuspenseWithPerf**(`__namedParameters`: { children: ReactNode ; fallback: ReactNode ; firePerf: undefined \| Performance ; traceId: string  }): Element
 
-*Defined in [src/performance.tsx:12](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/performance.tsx#L12)*
+*Defined in [src/performance.tsx:12](https://github.com/FirebaseExtended/reactfire/blob/master/src/performance.tsx#L12)*
 
 #### Parameters:
 

--- a/docs/reference/modules/_remote_config_getvalue_.md
+++ b/docs/reference/modules/_remote_config_getvalue_.md
@@ -31,7 +31,7 @@
 
 Ƭ  **AllParameters**: { [key:string]: [RemoteConfigValue](_remote_config_getvalue_.md#remoteconfigvalue);  }
 
-*Defined in [src/remote-config/getValue.tsx:6](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/getValue.tsx#L6)*
+*Defined in [src/remote-config/getValue.tsx:6](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/getValue.tsx#L6)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 Ƭ  **RemoteConfig**: RemoteConfig
 
-*Defined in [src/remote-config/getValue.tsx:3](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/getValue.tsx#L3)*
+*Defined in [src/remote-config/getValue.tsx:3](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/getValue.tsx#L3)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 Ƭ  **RemoteConfigValue**: Value
 
-*Defined in [src/remote-config/getValue.tsx:4](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/getValue.tsx#L4)*
+*Defined in [src/remote-config/getValue.tsx:4](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/getValue.tsx#L4)*
 
 ## Functions
 
@@ -55,7 +55,7 @@ ___
 
 ▸ **getAll**(`remoteConfig`: RemoteConfig): Observable\<[AllParameters](_remote_config_getvalue_.md#allparameters)>
 
-*Defined in [src/remote-config/getValue.tsx:47](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/getValue.tsx#L47)*
+*Defined in [src/remote-config/getValue.tsx:47](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/getValue.tsx#L47)*
 
 #### Parameters:
 
@@ -71,7 +71,7 @@ ___
 
 ▸ **getBoolean**(`remoteConfig`: RemoteConfig, `key`: string): Observable\<boolean>
 
-*Defined in [src/remote-config/getValue.tsx:42](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/getValue.tsx#L42)*
+*Defined in [src/remote-config/getValue.tsx:42](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/getValue.tsx#L42)*
 
 #### Parameters:
 
@@ -88,7 +88,7 @@ ___
 
 ▸ **getNumber**(`remoteConfig`: RemoteConfig, `key`: string): Observable\<number>
 
-*Defined in [src/remote-config/getValue.tsx:37](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/getValue.tsx#L37)*
+*Defined in [src/remote-config/getValue.tsx:37](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/getValue.tsx#L37)*
 
 #### Parameters:
 
@@ -105,7 +105,7 @@ ___
 
 ▸ **getString**(`remoteConfig`: RemoteConfig, `key`: string): Observable\<string>
 
-*Defined in [src/remote-config/getValue.tsx:32](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/getValue.tsx#L32)*
+*Defined in [src/remote-config/getValue.tsx:32](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/getValue.tsx#L32)*
 
 #### Parameters:
 
@@ -122,7 +122,7 @@ ___
 
 ▸ **getValue**(`remoteConfig`: RemoteConfig, `key`: string): Observable\<Value>
 
-*Defined in [src/remote-config/getValue.tsx:27](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/getValue.tsx#L27)*
+*Defined in [src/remote-config/getValue.tsx:27](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/getValue.tsx#L27)*
 
 #### Parameters:
 
@@ -139,7 +139,7 @@ ___
 
 ▸ **parameter$**\<T>(`__namedParameters`: { getter: (key: string) => T ; key: string ; remoteConfig: RemoteConfig  }): Observable\<T>
 
-*Defined in [src/remote-config/getValue.tsx:17](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/getValue.tsx#L17)*
+*Defined in [src/remote-config/getValue.tsx:17](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/getValue.tsx#L17)*
 
 #### Type parameters:
 

--- a/docs/reference/modules/_remote_config_index_.md
+++ b/docs/reference/modules/_remote_config_index_.md
@@ -31,7 +31,7 @@
 
 Ƭ  **Getter$**\<T>: (remoteConfig: RemoteConfig, key: string) => Observable\<T>
 
-*Defined in [src/remote-config/index.tsx:8](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/index.tsx#L8)*
+*Defined in [src/remote-config/index.tsx:8](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/index.tsx#L8)*
 
 #### Type parameters:
 
@@ -45,7 +45,7 @@ ___
 
 Ƭ  **RemoteConfig**: RemoteConfig
 
-*Defined in [src/remote-config/index.tsx:6](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/index.tsx#L6)*
+*Defined in [src/remote-config/index.tsx:6](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/index.tsx#L6)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 Ƭ  **RemoteConfigValue**: Value
 
-*Defined in [src/remote-config/index.tsx:7](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/index.tsx#L7)*
+*Defined in [src/remote-config/index.tsx:7](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/index.tsx#L7)*
 
 ## Functions
 
@@ -61,7 +61,7 @@ ___
 
 ▸ **useRemoteConfigAll**(`key`: string, `remoteConfig?`: [RemoteConfig](_remote_config_index_.md#remoteconfig)): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<[AllParameters](_remote_config_getvalue_.md#allparameters)>
 
-*Defined in [src/remote-config/index.tsx:79](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/index.tsx#L79)*
+*Defined in [src/remote-config/index.tsx:79](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/index.tsx#L79)*
 
 Convience method similar to useRemoteConfigValue. Returns allRemote Config parameters.
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **useRemoteConfigBoolean**(`key`: string, `remoteConfig?`: [RemoteConfig](_remote_config_index_.md#remoteconfig)): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<boolean>
 
-*Defined in [src/remote-config/index.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/index.tsx#L70)*
+*Defined in [src/remote-config/index.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/index.tsx#L70)*
 
 Convience method similar to useRemoteConfigValue. Returns a `boolean` from a Remote Config parameter.
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **useRemoteConfigNumber**(`key`: string, `remoteConfig?`: [RemoteConfig](_remote_config_index_.md#remoteconfig)): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<number>
 
-*Defined in [src/remote-config/index.tsx:61](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/index.tsx#L61)*
+*Defined in [src/remote-config/index.tsx:61](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/index.tsx#L61)*
 
 Convience method similar to useRemoteConfigValue. Returns a `number` from a Remote Config parameter.
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **useRemoteConfigString**(`key`: string, `remoteConfig?`: [RemoteConfig](_remote_config_index_.md#remoteconfig)): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<string>
 
-*Defined in [src/remote-config/index.tsx:52](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/index.tsx#L52)*
+*Defined in [src/remote-config/index.tsx:52](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/index.tsx#L52)*
 
 Convience method similar to useRemoteConfigValue. Returns a `string` from a Remote Config parameter.
 
@@ -137,7 +137,7 @@ ___
 
 ▸ **useRemoteConfigValue**(`key`: string, `remoteConfig?`: [RemoteConfig](_remote_config_index_.md#remoteconfig)): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<[RemoteConfigValue](_remote_config_index_.md#remoteconfigvalue)>
 
-*Defined in [src/remote-config/index.tsx:43](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/index.tsx#L43)*
+*Defined in [src/remote-config/index.tsx:43](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/index.tsx#L43)*
 
 Accepts a key and optionally a Remote Config instance. Returns a
 Remote Config Value.
@@ -157,7 +157,7 @@ ___
 
 ▸ **useRemoteConfigValue_INTERNAL**\<T>(`key`: string, `getter`: [Getter$](_remote_config_index_.md#getter$)\<T>, `remoteConfig?`: [RemoteConfig](_remote_config_index_.md#remoteconfig)): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<T>
 
-*Defined in [src/remote-config/index.tsx:23](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/remote-config/index.tsx#L23)*
+*Defined in [src/remote-config/index.tsx:23](https://github.com/FirebaseExtended/reactfire/blob/master/src/remote-config/index.tsx#L23)*
 
 Helper function to construct type safe functions. Since Remote Config has
 methods that return different types for values, we need to be extra safe

--- a/docs/reference/modules/_sdk_.md
+++ b/docs/reference/modules/_sdk_.md
@@ -58,7 +58,7 @@
 
 Ƭ  **App**: App
 
-*Defined in [src/sdk.tsx:8](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L8)*
+*Defined in [src/sdk.tsx:8](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L8)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 Ƭ  **ComponentName**: \"analytics\" \| \"auth\" \| \"database\" \| \"firestore\" \| \"functions\" \| \"messaging\" \| \"performance\" \| \"remoteConfig\" \| \"storage\"
 
-*Defined in [src/sdk.tsx:5](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L5)*
+*Defined in [src/sdk.tsx:5](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L5)*
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 Ƭ  **FirebaseInstanceFactory**: [ValueOf](_sdk_.md#valueof)\<Pick\<App, [ComponentName](_sdk_.md#componentname)>>
 
-*Defined in [src/sdk.tsx:9](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L9)*
+*Defined in [src/sdk.tsx:9](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L9)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 Ƭ  **FirebaseNamespaceComponent**: [ValueOf](_sdk_.md#valueof)\<Pick\<*typeof* firebase, [ComponentName](_sdk_.md#componentname)>>
 
-*Defined in [src/sdk.tsx:10](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L10)*
+*Defined in [src/sdk.tsx:10](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L10)*
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 Ƭ  **PreloadOptions**\<T>: { firebaseApp: App ; setup?: undefined \| (instanceFactory: T) => void \| Promise\<any> ; suspense?: undefined \| false \| true  }
 
-*Defined in [src/sdk.tsx:99](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L99)*
+*Defined in [src/sdk.tsx:99](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L99)*
 
 #### Type parameters:
 
@@ -112,7 +112,7 @@ ___
 
 Ƭ  **ValueOf**\<T>: T[keyof T]
 
-*Defined in [src/sdk.tsx:7](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L7)*
+*Defined in [src/sdk.tsx:7](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L7)*
 
 #### Type parameters:
 
@@ -126,7 +126,7 @@ Name |
 
 • `Const` **analytics**: analytics = useAnalytics
 
-*Defined in [src/sdk.tsx:90](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L90)*
+*Defined in [src/sdk.tsx:90](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L90)*
 
 ___
 
@@ -134,7 +134,7 @@ ___
 
 • `Const` **auth**: auth = useAuth
 
-*Defined in [src/sdk.tsx:89](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L89)*
+*Defined in [src/sdk.tsx:89](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L89)*
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 • `Const` **database**: database = useDatabase
 
-*Defined in [src/sdk.tsx:91](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L91)*
+*Defined in [src/sdk.tsx:91](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L91)*
 
 ___
 
@@ -150,7 +150,7 @@ ___
 
 • `Const` **firestore**: firestore = useFirestore
 
-*Defined in [src/sdk.tsx:92](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L92)*
+*Defined in [src/sdk.tsx:92](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L92)*
 
 ___
 
@@ -158,7 +158,7 @@ ___
 
 • `Const` **functions**: functions = useFunctions
 
-*Defined in [src/sdk.tsx:93](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L93)*
+*Defined in [src/sdk.tsx:93](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L93)*
 
 ___
 
@@ -166,7 +166,7 @@ ___
 
 • `Const` **messaging**: messaging = useMessaging
 
-*Defined in [src/sdk.tsx:94](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L94)*
+*Defined in [src/sdk.tsx:94](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L94)*
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 • `Const` **performance**: performance = usePerformance
 
-*Defined in [src/sdk.tsx:95](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L95)*
+*Defined in [src/sdk.tsx:95](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L95)*
 
 ___
 
@@ -182,7 +182,7 @@ ___
 
 • `Const` **preloadAnalytics**: (options: [PreloadOptions](_sdk_.md#preloadoptions)\<App[\"analytics\"]>) => Promise\<App[\"analytics\"]> = preloadFactory('analytics')
 
-*Defined in [src/sdk.tsx:141](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L141)*
+*Defined in [src/sdk.tsx:141](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L141)*
 
 ___
 
@@ -190,7 +190,7 @@ ___
 
 • `Const` **preloadAuth**: (options: [PreloadOptions](_sdk_.md#preloadoptions)\<App[\"auth\"]>) => Promise\<App[\"auth\"]> = preloadFactory('auth')
 
-*Defined in [src/sdk.tsx:140](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L140)*
+*Defined in [src/sdk.tsx:140](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L140)*
 
 ___
 
@@ -198,7 +198,7 @@ ___
 
 • `Const` **preloadDatabase**: (options: [PreloadOptions](_sdk_.md#preloadoptions)\<App[\"database\"]>) => Promise\<App[\"database\"]> = preloadFactory('database')
 
-*Defined in [src/sdk.tsx:142](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L142)*
+*Defined in [src/sdk.tsx:142](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L142)*
 
 ___
 
@@ -206,7 +206,7 @@ ___
 
 • `Const` **preloadFirestore**: (options: [PreloadOptions](_sdk_.md#preloadoptions)\<App[\"firestore\"]>) => Promise\<App[\"firestore\"]> = preloadFactory('firestore')
 
-*Defined in [src/sdk.tsx:143](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L143)*
+*Defined in [src/sdk.tsx:143](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L143)*
 
 ___
 
@@ -214,7 +214,7 @@ ___
 
 • `Const` **preloadFunctions**: (options: [PreloadOptions](_sdk_.md#preloadoptions)\<App[\"functions\"]>) => Promise\<App[\"functions\"]> = preloadFactory('functions')
 
-*Defined in [src/sdk.tsx:144](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L144)*
+*Defined in [src/sdk.tsx:144](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L144)*
 
 ___
 
@@ -222,7 +222,7 @@ ___
 
 • `Const` **preloadMessaging**: (options: [PreloadOptions](_sdk_.md#preloadoptions)\<App[\"messaging\"]>) => Promise\<App[\"messaging\"]> = preloadFactory('messaging')
 
-*Defined in [src/sdk.tsx:145](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L145)*
+*Defined in [src/sdk.tsx:145](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L145)*
 
 ___
 
@@ -230,7 +230,7 @@ ___
 
 • `Const` **preloadPerformance**: (options: [PreloadOptions](_sdk_.md#preloadoptions)\<App[\"performance\"]>) => Promise\<App[\"performance\"]> = preloadFactory('performance')
 
-*Defined in [src/sdk.tsx:146](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L146)*
+*Defined in [src/sdk.tsx:146](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L146)*
 
 ___
 
@@ -238,7 +238,7 @@ ___
 
 • `Const` **preloadRemoteConfig**: (options: [PreloadOptions](_sdk_.md#preloadoptions)\<App[\"remoteConfig\"]>) => Promise\<App[\"remoteConfig\"]> = preloadFactory('remoteConfig')
 
-*Defined in [src/sdk.tsx:147](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L147)*
+*Defined in [src/sdk.tsx:147](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L147)*
 
 ___
 
@@ -246,7 +246,7 @@ ___
 
 • `Const` **preloadStorage**: (options: [PreloadOptions](_sdk_.md#preloadoptions)\<App[\"storage\"]>) => Promise\<App[\"storage\"]> = preloadFactory('storage')
 
-*Defined in [src/sdk.tsx:148](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L148)*
+*Defined in [src/sdk.tsx:148](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L148)*
 
 ___
 
@@ -254,7 +254,7 @@ ___
 
 • `Const` **remoteConfig**: remoteConfig = useRemoteConfig
 
-*Defined in [src/sdk.tsx:96](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L96)*
+*Defined in [src/sdk.tsx:96](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L96)*
 
 ___
 
@@ -262,7 +262,7 @@ ___
 
 • `Const` **storage**: storage = useStorage
 
-*Defined in [src/sdk.tsx:97](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L97)*
+*Defined in [src/sdk.tsx:97](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L97)*
 
 ___
 
@@ -270,7 +270,7 @@ ___
 
 • `Const` **useAnalytics**: analytics = proxyComponent('analytics')
 
-*Defined in [src/sdk.tsx:80](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L80)*
+*Defined in [src/sdk.tsx:80](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L80)*
 
 ___
 
@@ -278,7 +278,7 @@ ___
 
 • `Const` **useAuth**: auth = proxyComponent('auth')
 
-*Defined in [src/sdk.tsx:79](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L79)*
+*Defined in [src/sdk.tsx:79](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L79)*
 
 ___
 
@@ -286,7 +286,7 @@ ___
 
 • `Const` **useDatabase**: database = proxyComponent('database')
 
-*Defined in [src/sdk.tsx:81](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L81)*
+*Defined in [src/sdk.tsx:81](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L81)*
 
 ___
 
@@ -294,7 +294,7 @@ ___
 
 • `Const` **useFirestore**: firestore = proxyComponent('firestore')
 
-*Defined in [src/sdk.tsx:82](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L82)*
+*Defined in [src/sdk.tsx:82](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L82)*
 
 ___
 
@@ -302,7 +302,7 @@ ___
 
 • `Const` **useFunctions**: functions = proxyComponent('functions')
 
-*Defined in [src/sdk.tsx:83](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L83)*
+*Defined in [src/sdk.tsx:83](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L83)*
 
 ___
 
@@ -310,7 +310,7 @@ ___
 
 • `Const` **useMessaging**: messaging = proxyComponent('messaging')
 
-*Defined in [src/sdk.tsx:84](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L84)*
+*Defined in [src/sdk.tsx:84](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L84)*
 
 ___
 
@@ -318,7 +318,7 @@ ___
 
 • `Const` **usePerformance**: performance = proxyComponent('performance')
 
-*Defined in [src/sdk.tsx:85](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L85)*
+*Defined in [src/sdk.tsx:85](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L85)*
 
 ___
 
@@ -326,7 +326,7 @@ ___
 
 • `Const` **useRemoteConfig**: remoteConfig = proxyComponent('remoteConfig')
 
-*Defined in [src/sdk.tsx:86](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L86)*
+*Defined in [src/sdk.tsx:86](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L86)*
 
 ___
 
@@ -334,7 +334,7 @@ ___
 
 • `Const` **useStorage**: storage = proxyComponent('storage')
 
-*Defined in [src/sdk.tsx:87](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L87)*
+*Defined in [src/sdk.tsx:87](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L87)*
 
 ## Functions
 
@@ -342,7 +342,7 @@ ___
 
 ▸ **importSDK**(`sdk`: [ComponentName](_sdk_.md#componentname)): Promise\<any>
 
-*Defined in [src/sdk.tsx:12](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L12)*
+*Defined in [src/sdk.tsx:12](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L12)*
 
 #### Parameters:
 
@@ -358,7 +358,7 @@ ___
 
 ▸ **preload**(`componentName`: [ComponentName](_sdk_.md#componentname), `firebaseApp`: App, `settingsCallback?`: (instanceFactory: [FirebaseInstanceFactory](_sdk_.md#firebaseinstancefactory)) => any): [SuspenseSubject](../classes/_suspensesubject_.suspensesubject.md)\<unknown>
 
-*Defined in [src/sdk.tsx:118](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L118)*
+*Defined in [src/sdk.tsx:118](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L118)*
 
 #### Parameters:
 
@@ -376,7 +376,7 @@ ___
 
 ▸ **preloadFactory**(`componentName`: \"auth\"): function
 
-*Defined in [src/sdk.tsx:105](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L105)*
+*Defined in [src/sdk.tsx:105](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L105)*
 
 #### Parameters:
 
@@ -388,7 +388,7 @@ Name | Type |
 
 ▸ **preloadFactory**(`componentName`: \"analytics\"): function
 
-*Defined in [src/sdk.tsx:106](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L106)*
+*Defined in [src/sdk.tsx:106](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L106)*
 
 #### Parameters:
 
@@ -400,7 +400,7 @@ Name | Type |
 
 ▸ **preloadFactory**(`componentName`: \"database\"): function
 
-*Defined in [src/sdk.tsx:107](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L107)*
+*Defined in [src/sdk.tsx:107](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L107)*
 
 #### Parameters:
 
@@ -412,7 +412,7 @@ Name | Type |
 
 ▸ **preloadFactory**(`componentName`: \"firestore\"): function
 
-*Defined in [src/sdk.tsx:108](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L108)*
+*Defined in [src/sdk.tsx:108](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L108)*
 
 #### Parameters:
 
@@ -424,7 +424,7 @@ Name | Type |
 
 ▸ **preloadFactory**(`componentName`: \"functions\"): function
 
-*Defined in [src/sdk.tsx:109](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L109)*
+*Defined in [src/sdk.tsx:109](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L109)*
 
 #### Parameters:
 
@@ -436,7 +436,7 @@ Name | Type |
 
 ▸ **preloadFactory**(`componentName`: \"messaging\"): function
 
-*Defined in [src/sdk.tsx:110](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L110)*
+*Defined in [src/sdk.tsx:110](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L110)*
 
 #### Parameters:
 
@@ -448,7 +448,7 @@ Name | Type |
 
 ▸ **preloadFactory**(`componentName`: \"performance\"): function
 
-*Defined in [src/sdk.tsx:111](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L111)*
+*Defined in [src/sdk.tsx:111](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L111)*
 
 #### Parameters:
 
@@ -460,7 +460,7 @@ Name | Type |
 
 ▸ **preloadFactory**(`componentName`: \"remoteConfig\"): function
 
-*Defined in [src/sdk.tsx:112](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L112)*
+*Defined in [src/sdk.tsx:112](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L112)*
 
 #### Parameters:
 
@@ -472,7 +472,7 @@ Name | Type |
 
 ▸ **preloadFactory**(`componentName`: \"storage\"): function
 
-*Defined in [src/sdk.tsx:113](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L113)*
+*Defined in [src/sdk.tsx:113](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L113)*
 
 #### Parameters:
 
@@ -488,7 +488,7 @@ ___
 
 ▸ **proxyComponent**(`componentName`: \"auth\"): *typeof* auth
 
-*Defined in [src/sdk.tsx:35](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L35)*
+*Defined in [src/sdk.tsx:35](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L35)*
 
 #### Parameters:
 
@@ -500,7 +500,7 @@ Name | Type |
 
 ▸ **proxyComponent**(`componentName`: \"analytics\"): *typeof* analytics
 
-*Defined in [src/sdk.tsx:36](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L36)*
+*Defined in [src/sdk.tsx:36](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L36)*
 
 #### Parameters:
 
@@ -512,7 +512,7 @@ Name | Type |
 
 ▸ **proxyComponent**(`componentName`: \"database\"): *typeof* database
 
-*Defined in [src/sdk.tsx:37](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L37)*
+*Defined in [src/sdk.tsx:37](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L37)*
 
 #### Parameters:
 
@@ -524,7 +524,7 @@ Name | Type |
 
 ▸ **proxyComponent**(`componentName`: \"firestore\"): *typeof* firestore
 
-*Defined in [src/sdk.tsx:38](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L38)*
+*Defined in [src/sdk.tsx:38](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L38)*
 
 #### Parameters:
 
@@ -536,7 +536,7 @@ Name | Type |
 
 ▸ **proxyComponent**(`componentName`: \"functions\"): *typeof* functions
 
-*Defined in [src/sdk.tsx:39](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L39)*
+*Defined in [src/sdk.tsx:39](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L39)*
 
 #### Parameters:
 
@@ -548,7 +548,7 @@ Name | Type |
 
 ▸ **proxyComponent**(`componentName`: \"messaging\"): *typeof* messaging
 
-*Defined in [src/sdk.tsx:40](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L40)*
+*Defined in [src/sdk.tsx:40](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L40)*
 
 #### Parameters:
 
@@ -560,7 +560,7 @@ Name | Type |
 
 ▸ **proxyComponent**(`componentName`: \"performance\"): *typeof* performance
 
-*Defined in [src/sdk.tsx:41](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L41)*
+*Defined in [src/sdk.tsx:41](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L41)*
 
 #### Parameters:
 
@@ -572,7 +572,7 @@ Name | Type |
 
 ▸ **proxyComponent**(`componentName`: \"remoteConfig\"): *typeof* remoteConfig
 
-*Defined in [src/sdk.tsx:42](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L42)*
+*Defined in [src/sdk.tsx:42](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L42)*
 
 #### Parameters:
 
@@ -584,7 +584,7 @@ Name | Type |
 
 ▸ **proxyComponent**(`componentName`: \"storage\"): *typeof* storage
 
-*Defined in [src/sdk.tsx:43](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/sdk.tsx#L43)*
+*Defined in [src/sdk.tsx:43](https://github.com/FirebaseExtended/reactfire/blob/master/src/sdk.tsx#L43)*
 
 #### Parameters:
 

--- a/docs/reference/modules/_storage_.md
+++ b/docs/reference/modules/_storage_.md
@@ -25,7 +25,7 @@
 
 Ƭ  **StorageImageProps**: { placeHolder?: JSX.Element ; storage?: firebase.storage.Storage ; storagePath: string ; suspense?: undefined \| false \| true  }
 
-*Defined in [src/storage.tsx:60](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/storage.tsx#L60)*
+*Defined in [src/storage.tsx:60](https://github.com/FirebaseExtended/reactfire/blob/master/src/storage.tsx#L60)*
 
 #### Type declaration:
 
@@ -42,7 +42,7 @@ Name | Type |
 
 ▸ **INTERNALStorageImage**(`props`: [StorageImageProps](_storage_.md#storageimageprops) & React.DetailedHTMLProps\<ImgHTMLAttributes\<HTMLImageElement>, HTMLImageElement>): Element
 
-*Defined in [src/storage.tsx:75](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/storage.tsx#L75)*
+*Defined in [src/storage.tsx:75](https://github.com/FirebaseExtended/reactfire/blob/master/src/storage.tsx#L75)*
 
 #### Parameters:
 
@@ -58,7 +58,7 @@ ___
 
 ▸ **StorageFromContext**(`props`: [StorageImageProps](_storage_.md#storageimageprops) & React.DetailedHTMLProps\<ImgHTMLAttributes\<HTMLImageElement>, HTMLImageElement>): Element
 
-*Defined in [src/storage.tsx:67](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/storage.tsx#L67)*
+*Defined in [src/storage.tsx:67](https://github.com/FirebaseExtended/reactfire/blob/master/src/storage.tsx#L67)*
 
 #### Parameters:
 
@@ -74,7 +74,7 @@ ___
 
 ▸ **StorageImage**(`props`: [StorageImageProps](_storage_.md#storageimageprops) & React.DetailedHTMLProps\<ImgHTMLAttributes\<HTMLImageElement>, HTMLImageElement>): Element
 
-*Defined in [src/storage.tsx:102](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/storage.tsx#L102)*
+*Defined in [src/storage.tsx:102](https://github.com/FirebaseExtended/reactfire/blob/master/src/storage.tsx#L102)*
 
 #### Parameters:
 
@@ -90,7 +90,7 @@ ___
 
 ▸ **_fromTask**(`task`: UploadTask): Observable\<UploadTaskSnapshot>
 
-*Defined in [src/storage.tsx:13](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/storage.tsx#L13)*
+*Defined in [src/storage.tsx:13](https://github.com/FirebaseExtended/reactfire/blob/master/src/storage.tsx#L13)*
 
 modified version of rxFire's _fromTask
 
@@ -108,7 +108,7 @@ ___
 
 ▸ **useStorageDownloadURL**\<T>(`ref`: Reference, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<string \| T>
 
-*Defined in [src/storage.tsx:53](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/storage.tsx#L53)*
+*Defined in [src/storage.tsx:53](https://github.com/FirebaseExtended/reactfire/blob/master/src/storage.tsx#L53)*
 
 Subscribe to a storage ref's download URL
 
@@ -133,7 +133,7 @@ ___
 
 ▸ **useStorageTask**\<T>(`task`: UploadTask, `ref`: Reference, `options?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)\<T>): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<UploadTaskSnapshot \| T>
 
-*Defined in [src/storage.tsx:36](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/storage.tsx#L36)*
+*Defined in [src/storage.tsx:36](https://github.com/FirebaseExtended/reactfire/blob/master/src/storage.tsx#L36)*
 
 Subscribe to the progress of a storage task
 

--- a/docs/reference/modules/_useobservable_.md
+++ b/docs/reference/modules/_useobservable_.md
@@ -26,7 +26,7 @@
 
 • `Const` **DEFAULT\_TIMEOUT**: 30000 = 30000
 
-*Defined in [src/useObservable.ts:7](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/useObservable.ts#L7)*
+*Defined in [src/useObservable.ts:7](https://github.com/FirebaseExtended/reactfire/blob/master/src/useObservable.ts#L7)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 • `Const` **preloadedObservables**: Map\<string, [SuspenseSubject](../classes/_suspensesubject_.suspensesubject.md)\<any>> = ((globalThis as any) as ReactFireGlobals).\_reactFirePreloadedObservables \|\| new Map()
 
-*Defined in [src/useObservable.ts:10](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/useObservable.ts#L10)*
+*Defined in [src/useObservable.ts:10](https://github.com/FirebaseExtended/reactfire/blob/master/src/useObservable.ts#L10)*
 
 ## Functions
 
@@ -42,7 +42,7 @@ ___
 
 ▸ **preloadObservable**\<T>(`source`: Observable\<T>, `id`: string): [SuspenseSubject](../classes/_suspensesubject_.suspensesubject.md)\<T>
 
-*Defined in [src/useObservable.ts:19](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/useObservable.ts#L19)*
+*Defined in [src/useObservable.ts:19](https://github.com/FirebaseExtended/reactfire/blob/master/src/useObservable.ts#L19)*
 
 #### Type parameters:
 
@@ -65,7 +65,7 @@ ___
 
 ▸ **useObservable**\<T>(`observableId`: string, `source`: Observable\<T \| any>, `config?`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)): [ObservableStatus](../interfaces/_useobservable_.observablestatus.md)\<T>
 
-*Defined in [src/useObservable.ts:41](https://github.com/FirebaseExtended/reactfire/blob/16b6188/src/useObservable.ts#L41)*
+*Defined in [src/useObservable.ts:41](https://github.com/FirebaseExtended/reactfire/blob/master/src/useObservable.ts#L41)*
 
 #### Type parameters:
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "tsdx lint src test",
     "size": "size-limit",
     "analyze": "size-limit --why",
-    "docs": "typedoc --plugin typedoc-plugin-markdown --out ./docs/reference"
+    "docs": "typedoc --plugin typedoc-plugin-markdown --out ./docs/reference --gitRevision master"
   },
   "peerDependencies": {
     "firebase": "^8.1.1",


### PR DESCRIPTION
- Change script to generate links to master instead of a specific git commit
    - Regenerate reference docs so they all point to master
- Add a new GH Workflow that checks if reference docs need to be regenerated (I want to add this as a required check for every PR)

Review notes: This is a noisy PR. Ignore all `.md` files, just take a look at `package.json` and `docs.yaml`