### PR TITLE
Mark startWithValue deprecated and alias it to initialData

### DIFF
--- a/docs/reference/interfaces/_index_.reactfireoptions.md
+++ b/docs/reference/interfaces/_index_.reactfireoptions.md
@@ -20,6 +20,7 @@ Name | Default |
 
 * [idField](_index_.reactfireoptions.md#idfield)
 * [initialData](_index_.reactfireoptions.md#initialdata)
+* [startWithValue](_index_.reactfireoptions.md#startwithvalue)
 * [suspense](_index_.reactfireoptions.md#suspense)
 
 ## Properties
@@ -40,8 +41,18 @@ ___
 
 ___
 
+### startWithValue
+
+• `Optional` **startWithValue**: T \| any
+
+*Defined in [src/index.ts:16](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L16)*
+
+**`deprecated`** use initialData instead
+
+___
+
 ### suspense
 
 • `Optional` **suspense**: undefined \| false \| true
 
-*Defined in [src/index.ts:13](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L13)*
+*Defined in [src/index.ts:17](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L17)*

--- a/docs/reference/modules/_index_.md
+++ b/docs/reference/modules/_index_.md
@@ -493,7 +493,7 @@ Name | Type |
 
 ▸ **checkIdField**(`options`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)): any
 
-*Defined in [src/index.ts:29](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L29)*
+*Defined in [src/index.ts:33](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L33)*
 
 #### Parameters:
 
@@ -509,7 +509,7 @@ ___
 
 ▸ **checkOptions**(`options`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md), `field`: string): any
 
-*Defined in [src/index.ts:16](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L16)*
+*Defined in [src/index.ts:20](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L20)*
 
 #### Parameters:
 
@@ -526,7 +526,7 @@ ___
 
 ▸ **checkinitialData**(`options`: [ReactFireOptions](../interfaces/_index_.reactfireoptions.md)): any
 
-*Defined in [src/index.ts:25](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L25)*
+*Defined in [src/index.ts:29](https://github.com/FirebaseExtended/reactfire/blob/master/src/index.ts#L29)*
 
 #### Parameters:
 

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -35,8 +35,8 @@ export function useUser<T = unknown>(auth?: firebase.auth.Auth, options?: ReactF
   let currentUser = auth.currentUser;
 
   // If currentUser is available, skip initialData
-  if (options?.initialData && !currentUser) {
-    currentUser = options.initialData;
+  if ((options?.initialData ?? options?.startWithValue) && !currentUser) {
+    currentUser = options.initialData ?? options.startWithValue;
   }
 
   return useObservable(observableId, observable$, { ...options, initialData: currentUser });

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -34,8 +34,8 @@ export function useUser<T = unknown>(auth?: firebase.auth.Auth, options?: ReactF
 
   let currentUser = auth.currentUser;
 
-  // If currentUser is available, skip initialData
-  if ((options?.initialData ?? options?.startWithValue) && !currentUser) {
+  // Only use options.initialData if auth.currentUser is unavailable
+  if (!currentUser && (options?.initialData ?? options?.startWithValue)) {
     currentUser = options.initialData ?? options.startWithValue;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ export type ReactFireGlobals = {
 export interface ReactFireOptions<T = unknown> {
   idField?: string;
   initialData?: T | any;
+  /**
+   * @deprecated use initialData instead
+   */
+  startWithValue?: T | any;
   suspense?: boolean;
 }
 

--- a/src/storage.tsx
+++ b/src/storage.tsx
@@ -41,7 +41,7 @@ export function useStorageTask<T = unknown>(
   const observableId = `storage:task:${ref.toString()}`;
   const observable$ = _fromTask(task);
 
-  return useObservable(observableId, observable$, options ? options.initialData : undefined);
+  return useObservable(observableId, observable$, options ? options.initialData ?? options.startWithValue : undefined);
 }
 
 /**

--- a/src/storage.tsx
+++ b/src/storage.tsx
@@ -41,7 +41,7 @@ export function useStorageTask<T = unknown>(
   const observableId = `storage:task:${ref.toString()}`;
   const observable$ = _fromTask(task);
 
-  return useObservable(observableId, observable$, options ? options.initialData ?? options.startWithValue : undefined);
+  return useObservable(observableId, observable$, options);
 }
 
 /**

--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -44,17 +44,17 @@ export function useObservable<T>(observableId: string, source: Observable<T | an
   }
   const observable = preloadObservable(source, observableId);
 
-  const hasInitialData = Object.keys(config).includes('initialData');
+  const hasInitialData = Object.keys(config).includes('initialData') || Object.keys(config).includes('startWithValue');
 
   const suspenseEnabled = useSuspenseEnabledFromConfigAndContext(config.suspense);
 
-  if (!observable.hasValue && !config?.initialData) {
+  if (!observable.hasValue && (!config?.initialData ?? !config?.startWithValue)) {
     if (suspenseEnabled === true) {
       throw observable.firstEmission;
     }
   }
 
-  const [latest, setValue] = React.useState(() => (observable.hasValue ? observable.value : config.initialData));
+  const [latest, setValue] = React.useState(() => (observable.hasValue ? observable.value : config.initialData ?? config.startWithValue));
   React.useEffect(() => {
     const subscription = observable.subscribe(
       v => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

Fixes #297 

We switched from `startWithValue` to `initialData` in ReactFire v3. This PR marks `startWithValue` deprecated instead of fully removing it, and checks for `startWithValue` and uses that if `initialData` isn't available.

Another option is to *only* mark `startWithValue` deprecated, and not check for it anywhere.