### PR TITLE
feat: added loader fallback to AuthCheck

### DIFF
--- a/docs/reference/interfaces/_auth_.authcheckprops.md
+++ b/docs/reference/interfaces/_auth_.authcheckprops.md
@@ -15,6 +15,7 @@
 * [auth](_auth_.authcheckprops.md#auth)
 * [children](_auth_.authcheckprops.md#children)
 * [fallback](_auth_.authcheckprops.md#fallback)
+* [loader](_auth_.authcheckprops.md#loader)
 * [requiredClaims](_auth_.authcheckprops.md#requiredclaims)
 
 ## Properties
@@ -31,13 +32,21 @@ ___
 
 •  **children**: React.ReactNode
 
-*Defined in [src/auth.tsx:63](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L63)*
+*Defined in [src/auth.tsx:64](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L64)*
 
 ___
 
 ### fallback
 
 •  **fallback**: React.ReactNode
+
+*Defined in [src/auth.tsx:63](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L63)*
+
+___
+
+### loader
+
+• `Optional` **loader**: React.ReactNode
 
 *Defined in [src/auth.tsx:62](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L62)*
 
@@ -47,4 +56,4 @@ ___
 
 • `Optional` **requiredClaims**: Object
 
-*Defined in [src/auth.tsx:64](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L64)*
+*Defined in [src/auth.tsx:65](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L65)*

--- a/docs/reference/interfaces/_auth_.claimscheckprops.md
+++ b/docs/reference/interfaces/_auth_.claimscheckprops.md
@@ -23,7 +23,7 @@
 
 •  **children**: React.ReactNode
 
-*Defined in [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L70)*
+*Defined in [src/auth.tsx:71](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L71)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 •  **fallback**: React.ReactNode
 
-*Defined in [src/auth.tsx:69](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L69)*
+*Defined in [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L70)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **requiredClaims**: undefined \| { [key:string]: any;  }
 
-*Defined in [src/auth.tsx:71](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L71)*
+*Defined in [src/auth.tsx:72](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L72)*
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 •  **user**: User
 
-*Defined in [src/auth.tsx:68](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L68)*
+*Defined in [src/auth.tsx:69](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L69)*

--- a/docs/reference/modules/_auth_.md
+++ b/docs/reference/modules/_auth_.md
@@ -23,15 +23,15 @@
 
 ### AuthCheck
 
-▸ **AuthCheck**(`__namedParameters`: { auth: undefined \| Auth ; children: ReactNode ; fallback: ReactNode ; requiredClaims: undefined \| Object  }): Element
+▸ **AuthCheck**(`__namedParameters`: { auth: undefined \| Auth ; children: ReactNode ; fallback: ReactNode ; loader: ReactNode ; requiredClaims: undefined \| Object  }): Element
 
-*Defined in [src/auth.tsx:97](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L97)*
+*Defined in [src/auth.tsx:98](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L98)*
 
 #### Parameters:
 
 Name | Type |
 ------ | ------ |
-`__namedParameters` | { auth: undefined \| Auth ; children: ReactNode ; fallback: ReactNode ; requiredClaims: undefined \| Object  } |
+`__namedParameters` | { auth: undefined \| Auth ; children: ReactNode ; fallback: ReactNode ; loader: ReactNode ; requiredClaims: undefined \| Object  } |
 
 **Returns:** Element
 
@@ -41,7 +41,7 @@ ___
 
 ▸ **ClaimsCheck**(`__namedParameters`: { children: ReactNode ; fallback: ReactNode ; requiredClaims: undefined \| { [key:string]: any;  } ; user: User  }): Element
 
-*Defined in [src/auth.tsx:74](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L74)*
+*Defined in [src/auth.tsx:75](https://github.com/FirebaseExtended/reactfire/blob/master/src/auth.tsx#L75)*
 
 #### Parameters:
 

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -59,6 +59,7 @@ export function useIdTokenResult(
 
 export interface AuthCheckProps {
   auth?: firebase.auth.Auth;
+  loader?: React.ReactNode;
   fallback: React.ReactNode;
   children: React.ReactNode;
   requiredClaims?: Object;
@@ -94,8 +95,9 @@ export function ClaimsCheck({ user, fallback, children, requiredClaims }: Claims
   }
 }
 
-export function AuthCheck({ auth, fallback, children, requiredClaims }: AuthCheckProps): JSX.Element {
-  const { data: user } = useUser<firebase.User>(auth);
+export function AuthCheck({ auth, loader, fallback, children, requiredClaims }: AuthCheckProps): JSX.Element {
+  const { data: user, status, hasEmitted } = useUser<firebase.User>(auth);
+  const isLoading = status === 'loading' || hasEmitted === false;
 
   if (user) {
     return requiredClaims ? (
@@ -105,6 +107,8 @@ export function AuthCheck({ auth, fallback, children, requiredClaims }: AuthChec
     ) : (
       <>{children}</>
     );
+  } else if (isLoading && loader) {
+    return <>{loader}</>;
   } else {
     return <>{fallback}</>;
   }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

When `<AuthCheck />` does its check and is in a loading state, we see a fallback component on the screen for a couple of moments. It would be nice to have an opportunity to see a loader instead.

### Code sample

```jsx
<AuthCheck
  fallback={<AuthView />}
  loader={<div>App is loading...</div>}
>
  <MyApp />
</AuthCheck>
```
