### PR TITLE
Provide an initial value for the claims object (#325)

### DIFF
--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -72,7 +72,7 @@ export interface ClaimsCheckProps {
 }
 
 export function ClaimsCheck({ user, fallback, children, requiredClaims }: ClaimsCheckProps) {
-  const { data } = useIdTokenResult(user, false);
+  const { data } = useIdTokenResult(user, false, { initialData: { claims: {} } });
   const { claims } = data;
   const missingClaims: { [key: string]: { expected: string; actual: string } } = {};
 


### PR DESCRIPTION
This PR captures the proposed fix for #325, i.e. providing a initialisation value for `claims`.

This prevents `TypeError: Cannot read property 'claims' of undefined` errors. This happened during tests using jsdom in my case, it was working fine in the Browser (Chrome).