### PR TITLE
Reduce checking a initial data

### DIFF
--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -44,7 +44,7 @@ export function useObservable<T>(observableId: string, source: Observable<T | an
   }
   const observable = preloadObservable(source, observableId);
 
-  const hasInitialData = Object.keys(config).includes('initialData') || Object.keys(config).includes('startWithValue');
+  const hasInitialData = config.hasOwnProperty('initialData') || config.hasOwnProperty('startWithValue');
 
   const suspenseEnabled = useSuspenseEnabledFromConfigAndContext(config.suspense);
 


### PR DESCRIPTION
Object.keys(...).includes(...) works fine too, but I think Object.prototype.hasOwnProperty(...) works better than that.
