### PR TITLE
Obey the Rules of Hooks

### DIFF
--- a/docs/reference/interfaces/auth.authcheckprops.md
+++ b/docs/reference/interfaces/auth.authcheckprops.md
@@ -8,26 +8,17 @@
 
 ### Properties
 
-- [auth](auth.authcheckprops.md#auth)
 - [children](auth.authcheckprops.md#children)
 - [fallback](auth.authcheckprops.md#fallback)
 - [requiredClaims](auth.authcheckprops.md#requiredclaims)
 
 ## Properties
 
-### auth
-
-• `Optional` **auth**: Auth
-
-Defined in: [src/auth.tsx:61](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L61)
-
-___
-
 ### children
 
 • **children**: ReactNode
 
-Defined in: [src/auth.tsx:63](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L63)
+Defined in: [src/auth.tsx:54](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L54)
 
 ___
 
@@ -35,7 +26,7 @@ ___
 
 • **fallback**: ReactNode
 
-Defined in: [src/auth.tsx:62](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L62)
+Defined in: [src/auth.tsx:53](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L53)
 
 ___
 
@@ -43,4 +34,4 @@ ___
 
 • `Optional` **requiredClaims**: Object
 
-Defined in: [src/auth.tsx:64](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L64)
+Defined in: [src/auth.tsx:55](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L55)

--- a/docs/reference/interfaces/auth.claimscheckprops.md
+++ b/docs/reference/interfaces/auth.claimscheckprops.md
@@ -19,7 +19,7 @@
 
 • **children**: ReactNode
 
-Defined in: [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L70)
+Defined in: [src/auth.tsx:61](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L61)
 
 ___
 
@@ -27,7 +27,7 @@ ___
 
 • **fallback**: ReactNode
 
-Defined in: [src/auth.tsx:69](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L69)
+Defined in: [src/auth.tsx:60](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L60)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Type declaration:
 
-Defined in: [src/auth.tsx:71](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L71)
+Defined in: [src/auth.tsx:62](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L62)
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 • **user**: User
 
-Defined in: [src/auth.tsx:68](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L68)
+Defined in: [src/auth.tsx:59](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L59)

--- a/docs/reference/modules/auth.md
+++ b/docs/reference/modules/auth.md
@@ -31,7 +31,7 @@
 
 **Returns:** JSX.Element
 
-Defined in: [src/auth.tsx:97](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L97)
+Defined in: [src/auth.tsx:88](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L88)
 
 ___
 
@@ -47,24 +47,24 @@ ___
 
 **Returns:** *Element*
 
-Defined in: [src/auth.tsx:74](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L74)
+Defined in: [src/auth.tsx:65](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L65)
 
 ___
 
 ### preloadUser
 
-▸ **preloadUser**(`options?`: { `firebaseApp?`: firebase.app.App  }): *Promise*<User\>
+▸ **preloadUser**(`options`: { `firebaseApp`: firebase.app.App  }): *Promise*<User\>
 
 #### Parameters:
 
 | Name | Type |
 | :------ | :------ |
-| `options?` | *object* |
-| `options.firebaseApp?` | firebase.app.App |
+| `options` | *object* |
+| `options.firebaseApp` | firebase.app.App |
 
 **Returns:** *Promise*<User\>
 
-Defined in: [src/auth.tsx:8](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L8)
+Defined in: [src/auth.tsx:7](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L7)
 
 ___
 
@@ -82,13 +82,13 @@ ___
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<firebase.auth.IdTokenResult\>
 
-Defined in: [src/auth.tsx:45](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L45)
+Defined in: [src/auth.tsx:37](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L37)
 
 ___
 
 ### useUser
 
-▸ **useUser**<T\>(`auth?`: firebase.auth.Auth, `options?`: [*ReactFireOptions*](../interfaces/index.reactfireoptions.md)<T\>): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<firebase.User\>
+▸ **useUser**<T\>(`options?`: [*ReactFireOptions*](../interfaces/index.reactfireoptions.md)<T\>): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<firebase.User\>
 
 Subscribe to Firebase auth state changes, including token refresh
 
@@ -100,11 +100,10 @@ Subscribe to Firebase auth state changes, including token refresh
 
 #### Parameters:
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `auth?` | firebase.auth.Auth | the [firebase.auth](https://firebase.google.com/docs/reference/js/firebase.auth) object |
-| `options?` | [*ReactFireOptions*](../interfaces/index.reactfireoptions.md)<T\> |  |
+| Name | Type |
+| :------ | :------ |
+| `options?` | [*ReactFireOptions*](../interfaces/index.reactfireoptions.md)<T\> |
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<firebase.User\>
 
-Defined in: [src/auth.tsx:24](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L24)
+Defined in: [src/auth.tsx:21](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L21)

--- a/docs/reference/modules/firestore.md
+++ b/docs/reference/modules/firestore.md
@@ -18,19 +18,19 @@
 
 ### preloadFirestoreDoc
 
-▸ **preloadFirestoreDoc**(`refProvider`: (`firestore`: firebase.firestore.Firestore) => firebase.firestore.DocumentReference, `options?`: { `firebaseApp?`: firebase.app.App  }): *Promise*<[*SuspenseSubject*](../classes/suspensesubject.suspensesubject-1.md)<DocumentSnapshot\>\>
+▸ **preloadFirestoreDoc**(`refProvider`: (`firestore`: firebase.firestore.Firestore) => firebase.firestore.DocumentReference, `options`: { `firebaseApp`: firebase.app.App  }): *Promise*<[*SuspenseSubject*](../classes/suspensesubject.suspensesubject-1.md)<DocumentSnapshot\>\>
 
 #### Parameters:
 
 | Name | Type |
 | :------ | :------ |
 | `refProvider` | (`firestore`: firebase.firestore.Firestore) => firebase.firestore.DocumentReference |
-| `options?` | *object* |
-| `options.firebaseApp?` | firebase.app.App |
+| `options` | *object* |
+| `options.firebaseApp` | firebase.app.App |
 
 **Returns:** *Promise*<[*SuspenseSubject*](../classes/suspensesubject.suspensesubject-1.md)<DocumentSnapshot\>\>
 
-Defined in: [src/firestore.tsx:29](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L29)
+Defined in: [src/firestore.tsx:28](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L28)
 
 ___
 
@@ -55,7 +55,7 @@ Subscribe to a Firestore collection
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<T *extends* {} ? T[] : firebase.firestore.QuerySnapshot\>
 
-Defined in: [src/firestore.tsx:110](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L110)
+Defined in: [src/firestore.tsx:108](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L108)
 
 ___
 
@@ -80,7 +80,7 @@ Subscribe to a Firestore collection and unwrap the snapshot.
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<T[]\>
 
-Defined in: [src/firestore.tsx:126](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L126)
+Defined in: [src/firestore.tsx:124](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L124)
 
 ___
 
@@ -105,7 +105,7 @@ Suscribe to Firestore Document changes
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<T *extends* {} ? T : firebase.firestore.DocumentSnapshot\>
 
-Defined in: [src/firestore.tsx:48](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L48)
+Defined in: [src/firestore.tsx:46](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L46)
 
 ___
 
@@ -130,7 +130,7 @@ Suscribe to Firestore Document changes
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<T\>
 
-Defined in: [src/firestore.tsx:80](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L80)
+Defined in: [src/firestore.tsx:78](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L78)
 
 ___
 
@@ -155,7 +155,7 @@ Get a firestore document and don't subscribe to changes
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<T\>
 
-Defined in: [src/firestore.tsx:95](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L95)
+Defined in: [src/firestore.tsx:93](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L93)
 
 ___
 
@@ -180,4 +180,4 @@ Get a firestore document and don't subscribe to changes
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<T *extends* {} ? T : firebase.firestore.DocumentSnapshot\>
 
-Defined in: [src/firestore.tsx:64](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L64)
+Defined in: [src/firestore.tsx:62](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L62)

--- a/docs/reference/modules/remote_config.md
+++ b/docs/reference/modules/remote_config.md
@@ -16,7 +16,7 @@
 
 ### useRemoteConfigAll
 
-▸ **useRemoteConfigAll**(`key`: *string*, `remoteConfig?`: RemoteConfig): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<[*AllParameters*](remote_config_getvalue.md#allparameters)\>
+▸ **useRemoteConfigAll**(`key`: *string*): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<[*AllParameters*](remote_config_getvalue.md#allparameters)\>
 
 Convience method similar to useRemoteConfigValue. Returns allRemote Config parameters.
 
@@ -25,17 +25,16 @@ Convience method similar to useRemoteConfigValue. Returns allRemote Config param
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `key` | *string* | The parameter key in Remote Config |
-| `remoteConfig?` | RemoteConfig | Optional instance. If not provided ReactFire will either grab the default instance or lazy load. |
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<[*AllParameters*](remote_config_getvalue.md#allparameters)\>
 
-Defined in: [src/remote-config/index.tsx:79](https://github.com/FirebaseExtended/reactfire/blob/main/src/remote-config/index.tsx#L79)
+Defined in: [src/remote-config/index.tsx:78](https://github.com/FirebaseExtended/reactfire/blob/main/src/remote-config/index.tsx#L78)
 
 ___
 
 ### useRemoteConfigBoolean
 
-▸ **useRemoteConfigBoolean**(`key`: *string*, `remoteConfig?`: RemoteConfig): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<boolean\>
+▸ **useRemoteConfigBoolean**(`key`: *string*): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<boolean\>
 
 Convience method similar to useRemoteConfigValue. Returns a `boolean` from a Remote Config parameter.
 
@@ -44,17 +43,16 @@ Convience method similar to useRemoteConfigValue. Returns a `boolean` from a Rem
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `key` | *string* | The parameter key in Remote Config |
-| `remoteConfig?` | RemoteConfig | Optional instance. If not provided ReactFire will either grab the default instance or lazy load. |
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<boolean\>
 
-Defined in: [src/remote-config/index.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/main/src/remote-config/index.tsx#L70)
+Defined in: [src/remote-config/index.tsx:69](https://github.com/FirebaseExtended/reactfire/blob/main/src/remote-config/index.tsx#L69)
 
 ___
 
 ### useRemoteConfigNumber
 
-▸ **useRemoteConfigNumber**(`key`: *string*, `remoteConfig?`: RemoteConfig): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<number\>
+▸ **useRemoteConfigNumber**(`key`: *string*): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<number\>
 
 Convience method similar to useRemoteConfigValue. Returns a `number` from a Remote Config parameter.
 
@@ -63,17 +61,16 @@ Convience method similar to useRemoteConfigValue. Returns a `number` from a Remo
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `key` | *string* | The parameter key in Remote Config |
-| `remoteConfig?` | RemoteConfig | Optional instance. If not provided ReactFire will either grab the default instance or lazy load. |
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<number\>
 
-Defined in: [src/remote-config/index.tsx:61](https://github.com/FirebaseExtended/reactfire/blob/main/src/remote-config/index.tsx#L61)
+Defined in: [src/remote-config/index.tsx:60](https://github.com/FirebaseExtended/reactfire/blob/main/src/remote-config/index.tsx#L60)
 
 ___
 
 ### useRemoteConfigString
 
-▸ **useRemoteConfigString**(`key`: *string*, `remoteConfig?`: RemoteConfig): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<string\>
+▸ **useRemoteConfigString**(`key`: *string*): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<string\>
 
 Convience method similar to useRemoteConfigValue. Returns a `string` from a Remote Config parameter.
 
@@ -82,17 +79,16 @@ Convience method similar to useRemoteConfigValue. Returns a `string` from a Remo
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `key` | *string* | The parameter key in Remote Config |
-| `remoteConfig?` | RemoteConfig | Optional instance. If not provided ReactFire will either grab the default instance or lazy load. |
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<string\>
 
-Defined in: [src/remote-config/index.tsx:52](https://github.com/FirebaseExtended/reactfire/blob/main/src/remote-config/index.tsx#L52)
+Defined in: [src/remote-config/index.tsx:51](https://github.com/FirebaseExtended/reactfire/blob/main/src/remote-config/index.tsx#L51)
 
 ___
 
 ### useRemoteConfigValue
 
-▸ **useRemoteConfigValue**(`key`: *string*, `remoteConfig?`: RemoteConfig): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<RemoteConfigValue\>
+▸ **useRemoteConfigValue**(`key`: *string*): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<RemoteConfigValue\>
 
 Accepts a key and optionally a Remote Config instance. Returns a
 Remote Config Value.
@@ -102,8 +98,7 @@ Remote Config Value.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `key` | *string* | The parameter key in Remote Config |
-| `remoteConfig?` | RemoteConfig | Optional instance. If not provided ReactFire will either grab the default instance or lazy load. |
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<RemoteConfigValue\>
 
-Defined in: [src/remote-config/index.tsx:43](https://github.com/FirebaseExtended/reactfire/blob/main/src/remote-config/index.tsx#L43)
+Defined in: [src/remote-config/index.tsx:42](https://github.com/FirebaseExtended/reactfire/blob/main/src/remote-config/index.tsx#L42)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "eslint": {
     "rules": {
-      "react-hooks/rules-of-hooks": "warn"
+      "react-hooks/rules-of-hooks": "error"
     }
   },
   "prettier": {

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -3,11 +3,9 @@ import * as React from 'react';
 import { user } from 'rxfire/auth';
 import { preloadAuth, preloadObservable, ReactFireOptions, useAuth, useObservable, ObservableStatus } from './';
 import { from } from 'rxjs';
-import { useFirebaseApp } from './firebaseApp';
 
-export function preloadUser(options?: { firebaseApp?: firebase.app.App }) {
-  // TODO: Find an alternative that doesn't break the rules of hooks (conditional hook call)
-  const firebaseApp = options?.firebaseApp || useFirebaseApp();
+export function preloadUser(options: { firebaseApp: firebase.app.App }) {
+  const firebaseApp = options.firebaseApp;
 
   return preloadAuth({ firebaseApp }).then(auth => {
     const result = preloadObservable(user(auth()), `auth:user:${firebaseApp.name}`);
@@ -18,16 +16,10 @@ export function preloadUser(options?: { firebaseApp?: firebase.app.App }) {
 /**
  * Subscribe to Firebase auth state changes, including token refresh
  *
- * @param auth - the [firebase.auth](https://firebase.google.com/docs/reference/js/firebase.auth) object
  * @param options
  */
-export function useUser<T = unknown>(auth?: firebase.auth.Auth, options?: ReactFireOptions<T>): ObservableStatus<firebase.User> {
-  // TODO: Find an alternative that doesn't break the rules of hooks (conditional hook call)
-  auth = auth || useAuth();
-
-  if (!auth) {
-    throw new Error('firebase.auth not found');
-  }
+export function useUser<T = unknown>(options?: ReactFireOptions<T>): ObservableStatus<firebase.User> {
+  const auth = useAuth();
 
   const observableId = `auth:user:${auth.app.name}`;
   const observable$ = user(auth);
@@ -58,7 +50,6 @@ export function useIdTokenResult(
 }
 
 export interface AuthCheckProps {
-  auth?: firebase.auth.Auth;
   fallback: React.ReactNode;
   children: React.ReactNode;
   requiredClaims?: Object;
@@ -94,8 +85,8 @@ export function ClaimsCheck({ user, fallback, children, requiredClaims }: Claims
   }
 }
 
-export function AuthCheck({ auth, fallback, children, requiredClaims }: AuthCheckProps): JSX.Element {
-  const { data: user } = useUser<firebase.User>(auth);
+export function AuthCheck({ fallback, children, requiredClaims }: AuthCheckProps): JSX.Element {
+  const { data: user } = useUser<firebase.User>();
 
   if (user) {
     return requiredClaims ? (

--- a/src/firestore.tsx
+++ b/src/firestore.tsx
@@ -3,7 +3,6 @@ import { collectionData, doc, docData, fromCollectionRef } from 'rxfire/firestor
 import { preloadFirestore, ReactFireOptions, useObservable, checkIdField, ReactFireGlobals } from './';
 import { preloadObservable, ObservableStatus } from './useObservable';
 import { first } from 'rxjs/operators';
-import { useFirebaseApp } from './firebaseApp';
 
 // Since we're side-effect free, we need to ensure our observableId cache is global
 const cachedQueries: Array<firebase.firestore.Query> = ((globalThis as any) as ReactFireGlobals)._reactFireFirestoreQueryCache || [];

--- a/src/firestore.tsx
+++ b/src/firestore.tsx
@@ -28,10 +28,9 @@ function getUniqueIdForFirestoreQuery(query: firebase.firestore.Query) {
 // has been imported, so it takes a refProvider instead of a ref
 export function preloadFirestoreDoc(
   refProvider: (firestore: firebase.firestore.Firestore) => firebase.firestore.DocumentReference,
-  options?: { firebaseApp?: firebase.app.App }
+  options: { firebaseApp: firebase.app.App }
 ) {
-  // TODO: Find an alternative that doesn't break the rules of hooks (conditional hook call)
-  const firebaseApp = options?.firebaseApp || useFirebaseApp();
+  const firebaseApp = options.firebaseApp;
 
   return preloadFirestore({ firebaseApp }).then(firestore => {
     const ref = refProvider(firestore());

--- a/src/performance.tsx
+++ b/src/performance.tsx
@@ -10,8 +10,9 @@ export interface SuspensePerfProps {
 }
 
 export function SuspenseWithPerf({ children, traceId, fallback, firePerf }: SuspensePerfProps): JSX.Element {
+  const firebaseApp = useFirebaseApp();
+
   if (!firePerf) {
-    const firebaseApp = useFirebaseApp();
     preloadPerformance({ firebaseApp }).then(perf => perf());
   }
 

--- a/src/remote-config/index.tsx
+++ b/src/remote-config/index.tsx
@@ -20,9 +20,8 @@ interface RemoteConfigWithPrivate extends RemoteConfig {
  * @param getter
  * @param remoteConfig
  */
-function useRemoteConfigValue_INTERNAL<T>(key: string, getter: Getter$<T>, remoteConfig?: RemoteConfig): ObservableStatus<T> {
-  // TODO: Find an alternative that doesn't break the rules of hooks (conditional hook call)
-  remoteConfig = remoteConfig || useRemoteConfig();
+function useRemoteConfigValue_INTERNAL<T>(key: string, getter: Getter$<T>): ObservableStatus<T> {
+  const remoteConfig = useRemoteConfig();
 
   // INVESTIGATE need to use a public API to get at the app name, one doesn't appear to exist...
   // we might need to iterate over the Firebase apps and check for remoteConfig equality? this works for now
@@ -40,8 +39,8 @@ function useRemoteConfigValue_INTERNAL<T>(key: string, getter: Getter$<T>, remot
  * @param key The parameter key in Remote Config
  * @param remoteConfig Optional instance. If not provided ReactFire will either grab the default instance or lazy load.
  */
-export function useRemoteConfigValue(key: string, remoteConfig?: RemoteConfig): ObservableStatus<RemoteConfigValue> {
-  return useRemoteConfigValue_INTERNAL<RemoteConfigValue>(key, getValue, remoteConfig);
+export function useRemoteConfigValue(key: string): ObservableStatus<RemoteConfigValue> {
+  return useRemoteConfigValue_INTERNAL<RemoteConfigValue>(key, getValue);
 }
 
 /**
@@ -49,8 +48,8 @@ export function useRemoteConfigValue(key: string, remoteConfig?: RemoteConfig): 
  * @param key The parameter key in Remote Config
  * @param remoteConfig Optional instance. If not provided ReactFire will either grab the default instance or lazy load.
  */
-export function useRemoteConfigString(key: string, remoteConfig?: RemoteConfig): ObservableStatus<string> {
-  return useRemoteConfigValue_INTERNAL<string>(key, getString, remoteConfig);
+export function useRemoteConfigString(key: string): ObservableStatus<string> {
+  return useRemoteConfigValue_INTERNAL<string>(key, getString);
 }
 
 /**
@@ -58,8 +57,8 @@ export function useRemoteConfigString(key: string, remoteConfig?: RemoteConfig):
  * @param key The parameter key in Remote Config
  * @param remoteConfig Optional instance. If not provided ReactFire will either grab the default instance or lazy load.
  */
-export function useRemoteConfigNumber(key: string, remoteConfig?: RemoteConfig): ObservableStatus<number> {
-  return useRemoteConfigValue_INTERNAL<number>(key, getNumber, remoteConfig);
+export function useRemoteConfigNumber(key: string): ObservableStatus<number> {
+  return useRemoteConfigValue_INTERNAL<number>(key, getNumber);
 }
 
 /**
@@ -67,8 +66,8 @@ export function useRemoteConfigNumber(key: string, remoteConfig?: RemoteConfig):
  * @param key The parameter key in Remote Config
  * @param remoteConfig Optional instance. If not provided ReactFire will either grab the default instance or lazy load.
  */
-export function useRemoteConfigBoolean(key: string, remoteConfig?: RemoteConfig): ObservableStatus<boolean> {
-  return useRemoteConfigValue_INTERNAL<boolean>(key, getBoolean, remoteConfig);
+export function useRemoteConfigBoolean(key: string): ObservableStatus<boolean> {
+  return useRemoteConfigValue_INTERNAL<boolean>(key, getBoolean);
 }
 
 /**
@@ -76,6 +75,6 @@ export function useRemoteConfigBoolean(key: string, remoteConfig?: RemoteConfig)
  * @param key The parameter key in Remote Config
  * @param remoteConfig Optional instance. If not provided ReactFire will either grab the default instance or lazy load.
  */
-export function useRemoteConfigAll(key: string, remoteConfig?: RemoteConfig): ObservableStatus<AllParameters> {
-  return useRemoteConfigValue_INTERNAL<AllParameters>(key, getAll, remoteConfig);
+export function useRemoteConfigAll(key: string): ObservableStatus<AllParameters> {
+  return useRemoteConfigValue_INTERNAL<AllParameters>(key, getAll);
 }

--- a/test/auth.test.tsx
+++ b/test/auth.test.tsx
@@ -80,17 +80,6 @@ describe('Authentication', () => {
       await waitFor(() => expect(getByTestId('signed-out')).toBeInTheDocument());
     });
 
-    it('can use firebase Auth from props', async () => {
-      const { getByTestId } = render(
-        <React.Suspense fallback={'loading'}>
-          <AuthCheck fallback={<h1 data-testid="signed-out">not signed in</h1>} auth={(app.auth() as unknown) as firebase.auth.Auth}>
-            {'signed in'}
-          </AuthCheck>
-        </React.Suspense>
-      );
-      await waitFor(() => expect(getByTestId('signed-out')).toBeInTheDocument());
-    });
-
     it('renders the fallback if a user is not signed in', async () => {
       const { getByTestId } = render(<AuthCheckWrapper />);
 

--- a/test/custom-jest-environment.js
+++ b/test/custom-jest-environment.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Correct Jest bug that prevents the Firestore tests from running. More info here:
  * https://github.com/firebase/firebase-js-sdk/issues/3096#issuecomment-637584185


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

fixes #337 

This is a breaking change to make ReactFire comply with the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html). 

- `firebaseApp` is no longer optional in the `preload*` functions - you have to pass it in
- You can no longer pass in your own `firebaseApp` instance to hooks
- You can no longer pass in your own `auth` instance  to `AuthCheck`