### PR TITLE
New Auth Hook: `useSigninCheck()` to replace `AuthCheck` and `ClaimsCheck` components

### DIFF
--- a/docs/reference/classes/index.reactfireerror.md
+++ b/docs/reference/classes/index.reactfireerror.md
@@ -1,0 +1,153 @@
+[ReactFire reference docs](../README.md) / [index](../modules/index.md) / ReactFireError
+
+# Class: ReactFireError
+
+[index](../modules/index.md).ReactFireError
+
+## Hierarchy
+
+* *Error*
+
+  ↳ **ReactFireError**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](index.reactfireerror.md#constructor)
+
+### Properties
+
+- [code](index.reactfireerror.md#code)
+- [customData](index.reactfireerror.md#customdata)
+- [message](index.reactfireerror.md#message)
+- [name](index.reactfireerror.md#name)
+- [stack](index.reactfireerror.md#stack)
+- [prepareStackTrace](index.reactfireerror.md#preparestacktrace)
+- [stackTraceLimit](index.reactfireerror.md#stacktracelimit)
+
+### Methods
+
+- [captureStackTrace](index.reactfireerror.md#capturestacktrace)
+
+## Constructors
+
+### constructor
+
+\+ **new ReactFireError**(`code`: *string*, `message`: *string*, `customData?`: *Record*<string, unknown\>): [*ReactFireError*](index.reactfireerror.md)
+
+#### Parameters:
+
+| Name | Type |
+| :------ | :------ |
+| `code` | *string* |
+| `message` | *string* |
+| `customData?` | *Record*<string, unknown\> |
+
+**Returns:** [*ReactFireError*](index.reactfireerror.md)
+
+Overrides: Error.constructor
+
+Defined in: [src/index.ts:11](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L11)
+
+## Properties
+
+### code
+
+• `Readonly` **code**: *string*
+
+___
+
+### customData
+
+• `Optional` **customData**: *Record*<string, unknown\>
+
+___
+
+### message
+
+• **message**: *string*
+
+Inherited from: Error.message
+
+Defined in: node_modules/typescript/lib/lib.es5.d.ts:974
+
+___
+
+### name
+
+• `Readonly` **name**: ``"ReactFireError"``= 'ReactFireError'
+
+Overrides: Error.name
+
+Defined in: [src/index.ts:11](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L11)
+
+___
+
+### stack
+
+• `Optional` **stack**: *string*
+
+Inherited from: Error.stack
+
+Defined in: node_modules/typescript/lib/lib.es5.d.ts:975
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: Error, `stackTraces`: CallSite[]) => *any*
+
+Optional override for formatting stack traces
+
+**`see`** https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+#### Type declaration:
+
+▸ (`err`: Error, `stackTraces`: CallSite[]): *any*
+
+#### Parameters:
+
+| Name | Type |
+| :------ | :------ |
+| `err` | Error |
+| `stackTraces` | CallSite[] |
+
+**Returns:** *any*
+
+Defined in: node_modules/@types/node/globals.d.ts:11
+
+Inherited from: Error.prepareStackTrace
+
+Defined in: node_modules/@types/node/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: *number*
+
+Inherited from: Error.stackTraceLimit
+
+Defined in: node_modules/@types/node/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static`**captureStackTrace**(`targetObject`: *object*, `constructorOpt?`: Function): *void*
+
+Create .stack property on a target object
+
+#### Parameters:
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | *object* |
+| `constructorOpt?` | Function |
+
+**Returns:** *void*
+
+Inherited from: Error.captureStackTrace
+
+Defined in: node_modules/@types/node/globals.d.ts:4

--- a/docs/reference/interfaces/auth.authcheckprops.md
+++ b/docs/reference/interfaces/auth.authcheckprops.md
@@ -19,7 +19,7 @@
 
 • `Optional` **auth**: Auth
 
-Defined in: [src/auth.tsx:61](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L61)
+Defined in: [src/auth.tsx:62](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L62)
 
 ___
 
@@ -27,7 +27,7 @@ ___
 
 • **children**: ReactNode
 
-Defined in: [src/auth.tsx:63](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L63)
+Defined in: [src/auth.tsx:64](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L64)
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 • **fallback**: ReactNode
 
-Defined in: [src/auth.tsx:62](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L62)
+Defined in: [src/auth.tsx:63](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L63)
 
 ___
 
@@ -43,4 +43,4 @@ ___
 
 • `Optional` **requiredClaims**: Object
 
-Defined in: [src/auth.tsx:64](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L64)
+Defined in: [src/auth.tsx:65](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L65)

--- a/docs/reference/interfaces/auth.claimcheckerrors.md
+++ b/docs/reference/interfaces/auth.claimcheckerrors.md
@@ -1,0 +1,9 @@
+[ReactFire reference docs](../README.md) / [auth](../modules/auth.md) / ClaimCheckErrors
+
+# Interface: ClaimCheckErrors
+
+[auth](../modules/auth.md).ClaimCheckErrors
+
+## Indexable
+
+▪ [key: *string*]: *any*[]

--- a/docs/reference/interfaces/auth.claimscheckprops.md
+++ b/docs/reference/interfaces/auth.claimscheckprops.md
@@ -19,7 +19,7 @@
 
 • **children**: ReactNode
 
-Defined in: [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L70)
+Defined in: [src/auth.tsx:71](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L71)
 
 ___
 
@@ -27,17 +27,17 @@ ___
 
 • **fallback**: ReactNode
 
-Defined in: [src/auth.tsx:69](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L69)
+Defined in: [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L70)
 
 ___
 
 ### requiredClaims
 
-• `Optional` **requiredClaims**: *object*
+• **requiredClaims**: *object*
 
 #### Type declaration:
 
-Defined in: [src/auth.tsx:71](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L71)
+Defined in: [src/auth.tsx:72](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L72)
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 • **user**: User
 
-Defined in: [src/auth.tsx:68](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L68)
+Defined in: [src/auth.tsx:69](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L69)

--- a/docs/reference/interfaces/auth.claimsvalidator.md
+++ b/docs/reference/interfaces/auth.claimsvalidator.md
@@ -21,4 +21,4 @@
 | `errors?` | ClaimCheckErrors |
 | `hasRequiredClaims` | *boolean* |
 
-Defined in: [src/auth.tsx:90](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L90)
+Defined in: [src/auth.tsx:91](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L91)

--- a/docs/reference/interfaces/auth.claimsvalidator.md
+++ b/docs/reference/interfaces/auth.claimsvalidator.md
@@ -21,4 +21,4 @@
 | `errors` | {} \| ClaimCheckErrors |
 | `hasRequiredClaims` | *boolean* |
 
-Defined in: [src/auth.tsx:91](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L91)
+Defined in: [src/auth.tsx:92](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L92)

--- a/docs/reference/interfaces/auth.claimsvalidator.md
+++ b/docs/reference/interfaces/auth.claimsvalidator.md
@@ -1,0 +1,24 @@
+[ReactFire reference docs](../README.md) / [auth](../modules/auth.md) / ClaimsValidator
+
+# Interface: ClaimsValidator
+
+[auth](../modules/auth.md).ClaimsValidator
+
+## Callable
+
+▸ **ClaimsValidator**(`claims`: { [key: string]: *any*;  }): *object*
+
+#### Parameters:
+
+| Name | Type |
+| :------ | :------ |
+| `claims` | *object* |
+
+**Returns:** *object*
+
+| Name | Type |
+| :------ | :------ |
+| `errors?` | ClaimCheckErrors |
+| `hasRequiredClaims` | *boolean* |
+
+Defined in: [src/auth.tsx:90](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L90)

--- a/docs/reference/interfaces/auth.claimsvalidator.md
+++ b/docs/reference/interfaces/auth.claimsvalidator.md
@@ -18,7 +18,7 @@
 
 | Name | Type |
 | :------ | :------ |
-| `errors?` | ClaimCheckErrors |
+| `errors` | {} \| ClaimCheckErrors |
 | `hasRequiredClaims` | *boolean* |
 
 Defined in: [src/auth.tsx:91](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L91)

--- a/docs/reference/interfaces/auth.claimsvalidator.md
+++ b/docs/reference/interfaces/auth.claimsvalidator.md
@@ -18,7 +18,7 @@
 
 | Name | Type |
 | :------ | :------ |
-| `errors` | {} \| ClaimCheckErrors |
+| `errors` | {} \| [*ClaimCheckErrors*](auth.claimcheckerrors.md) |
 | `hasRequiredClaims` | *boolean* |
 
 Defined in: [src/auth.tsx:92](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L92)

--- a/docs/reference/interfaces/auth.signincheckoptions.md
+++ b/docs/reference/interfaces/auth.signincheckoptions.md
@@ -1,0 +1,82 @@
+[ReactFire reference docs](../README.md) / [auth](../modules/auth.md) / SignInCheckOptions
+
+# Interface: SignInCheckOptions
+
+[auth](../modules/auth.md).SignInCheckOptions
+
+## Hierarchy
+
+* [*ReactFireOptions*](index.reactfireoptions.md)<[*SigninCheckResult*](../modules/auth.md#signincheckresult)\>
+
+  ↳ **SignInCheckOptions**
+
+## Table of contents
+
+### Properties
+
+- [forceRefresh](auth.signincheckoptions.md#forcerefresh)
+- [idField](auth.signincheckoptions.md#idfield)
+- [initialData](auth.signincheckoptions.md#initialdata)
+- [requiredClaims](auth.signincheckoptions.md#requiredclaims)
+- [startWithValue](auth.signincheckoptions.md#startwithvalue)
+- [suspense](auth.signincheckoptions.md#suspense)
+
+## Properties
+
+### forceRefresh
+
+• `Optional` **forceRefresh**: *boolean*
+
+Defined in: [src/auth.tsx:88](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L88)
+
+___
+
+### idField
+
+• `Optional` **idField**: *string*
+
+Inherited from: [ReactFireOptions](index.reactfireoptions.md).[idField](index.reactfireoptions.md#idfield)
+
+Defined in: [src/index.ts:11](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L11)
+
+___
+
+### initialData
+
+• `Optional` **initialData**: *any*
+
+Inherited from: [ReactFireOptions](index.reactfireoptions.md).[initialData](index.reactfireoptions.md#initialdata)
+
+Defined in: [src/index.ts:12](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L12)
+
+___
+
+### requiredClaims
+
+• `Optional` **requiredClaims**: *object*
+
+#### Type declaration:
+
+Defined in: [src/auth.tsx:87](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L87)
+
+___
+
+### startWithValue
+
+• `Optional` **startWithValue**: *any*
+
+**`deprecated`** use initialData instead
+
+Inherited from: [ReactFireOptions](index.reactfireoptions.md).[startWithValue](index.reactfireoptions.md#startwithvalue)
+
+Defined in: [src/index.ts:16](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L16)
+
+___
+
+### suspense
+
+• `Optional` **suspense**: *boolean*
+
+Inherited from: [ReactFireOptions](index.reactfireoptions.md).[suspense](index.reactfireoptions.md#suspense)
+
+Defined in: [src/index.ts:17](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L17)

--- a/docs/reference/interfaces/auth.signincheckoptions.md
+++ b/docs/reference/interfaces/auth.signincheckoptions.md
@@ -27,7 +27,7 @@
 
 • `Optional` **forceRefresh**: *boolean*
 
-Defined in: [src/auth.tsx:79](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L79)
+Defined in: [src/auth.tsx:84](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L84)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Type declaration:
 
-Defined in: [src/auth.tsx:78](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L78)
+Defined in: [src/auth.tsx:83](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L83)
 
 ___
 

--- a/docs/reference/interfaces/auth.signincheckoptionsbasic.md
+++ b/docs/reference/interfaces/auth.signincheckoptionsbasic.md
@@ -30,7 +30,7 @@
 
 • `Optional` **forceRefresh**: *boolean*
 
-Defined in: [src/auth.tsx:84](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L84)
+Defined in: [src/auth.tsx:85](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L85)
 
 ___
 

--- a/docs/reference/interfaces/auth.signincheckoptionsbasic.md
+++ b/docs/reference/interfaces/auth.signincheckoptionsbasic.md
@@ -1,25 +1,28 @@
-[ReactFire reference docs](../README.md) / [auth](../modules/auth.md) / SignInCheckOptions
+[ReactFire reference docs](../README.md) / [auth](../modules/auth.md) / SignInCheckOptionsBasic
 
-# Interface: SignInCheckOptions
+# Interface: SignInCheckOptionsBasic
 
-[auth](../modules/auth.md).SignInCheckOptions
+[auth](../modules/auth.md).SignInCheckOptionsBasic
 
 ## Hierarchy
 
 * [*ReactFireOptions*](index.reactfireoptions.md)<[*SigninCheckResult*](../modules/auth.md#signincheckresult)\>
 
-  ↳ **SignInCheckOptions**
+  ↳ **SignInCheckOptionsBasic**
+
+  ↳↳ [*SignInCheckOptionsClaimsObject*](auth.signincheckoptionsclaimsobject.md)
+
+  ↳↳ [*SignInCheckOptionsClaimsValidator*](auth.signincheckoptionsclaimsvalidator.md)
 
 ## Table of contents
 
 ### Properties
 
-- [forceRefresh](auth.signincheckoptions.md#forcerefresh)
-- [idField](auth.signincheckoptions.md#idfield)
-- [initialData](auth.signincheckoptions.md#initialdata)
-- [requiredClaims](auth.signincheckoptions.md#requiredclaims)
-- [startWithValue](auth.signincheckoptions.md#startwithvalue)
-- [suspense](auth.signincheckoptions.md#suspense)
+- [forceRefresh](auth.signincheckoptionsbasic.md#forcerefresh)
+- [idField](auth.signincheckoptionsbasic.md#idfield)
+- [initialData](auth.signincheckoptionsbasic.md#initialdata)
+- [startWithValue](auth.signincheckoptionsbasic.md#startwithvalue)
+- [suspense](auth.signincheckoptionsbasic.md#suspense)
 
 ## Properties
 
@@ -27,7 +30,7 @@
 
 • `Optional` **forceRefresh**: *boolean*
 
-Defined in: [src/auth.tsx:84](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L84)
+Defined in: [src/auth.tsx:83](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L83)
 
 ___
 
@@ -48,16 +51,6 @@ ___
 Inherited from: [ReactFireOptions](index.reactfireoptions.md).[initialData](index.reactfireoptions.md#initialdata)
 
 Defined in: [src/index.ts:12](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L12)
-
-___
-
-### requiredClaims
-
-• `Optional` **requiredClaims**: *object*
-
-#### Type declaration:
-
-Defined in: [src/auth.tsx:83](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L83)
 
 ___
 

--- a/docs/reference/interfaces/auth.signincheckoptionsbasic.md
+++ b/docs/reference/interfaces/auth.signincheckoptionsbasic.md
@@ -30,7 +30,7 @@
 
 • `Optional` **forceRefresh**: *boolean*
 
-Defined in: [src/auth.tsx:83](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L83)
+Defined in: [src/auth.tsx:84](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L84)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 Inherited from: [ReactFireOptions](index.reactfireoptions.md).[idField](index.reactfireoptions.md#idfield)
 
-Defined in: [src/index.ts:11](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L11)
+Defined in: [src/index.ts:23](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L23)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 Inherited from: [ReactFireOptions](index.reactfireoptions.md).[initialData](index.reactfireoptions.md#initialdata)
 
-Defined in: [src/index.ts:12](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L12)
+Defined in: [src/index.ts:24](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L24)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 Inherited from: [ReactFireOptions](index.reactfireoptions.md).[startWithValue](index.reactfireoptions.md#startwithvalue)
 
-Defined in: [src/index.ts:16](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L16)
+Defined in: [src/index.ts:28](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L28)
 
 ___
 
@@ -72,4 +72,4 @@ ___
 
 Inherited from: [ReactFireOptions](index.reactfireoptions.md).[suspense](index.reactfireoptions.md#suspense)
 
-Defined in: [src/index.ts:17](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L17)
+Defined in: [src/index.ts:29](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L29)

--- a/docs/reference/interfaces/auth.signincheckoptionsclaimsobject.md
+++ b/docs/reference/interfaces/auth.signincheckoptionsclaimsobject.md
@@ -1,0 +1,84 @@
+[ReactFire reference docs](../README.md) / [auth](../modules/auth.md) / SignInCheckOptionsClaimsObject
+
+# Interface: SignInCheckOptionsClaimsObject
+
+[auth](../modules/auth.md).SignInCheckOptionsClaimsObject
+
+## Hierarchy
+
+* [*SignInCheckOptionsBasic*](auth.signincheckoptionsbasic.md)
+
+  ↳ **SignInCheckOptionsClaimsObject**
+
+## Table of contents
+
+### Properties
+
+- [forceRefresh](auth.signincheckoptionsclaimsobject.md#forcerefresh)
+- [idField](auth.signincheckoptionsclaimsobject.md#idfield)
+- [initialData](auth.signincheckoptionsclaimsobject.md#initialdata)
+- [requiredClaims](auth.signincheckoptionsclaimsobject.md#requiredclaims)
+- [startWithValue](auth.signincheckoptionsclaimsobject.md#startwithvalue)
+- [suspense](auth.signincheckoptionsclaimsobject.md#suspense)
+
+## Properties
+
+### forceRefresh
+
+• `Optional` **forceRefresh**: *boolean*
+
+Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[forceRefresh](auth.signincheckoptionsbasic.md#forcerefresh)
+
+Defined in: [src/auth.tsx:83](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L83)
+
+___
+
+### idField
+
+• `Optional` **idField**: *string*
+
+Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[idField](auth.signincheckoptionsbasic.md#idfield)
+
+Defined in: [src/index.ts:11](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L11)
+
+___
+
+### initialData
+
+• `Optional` **initialData**: *any*
+
+Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[initialData](auth.signincheckoptionsbasic.md#initialdata)
+
+Defined in: [src/index.ts:12](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L12)
+
+___
+
+### requiredClaims
+
+• **requiredClaims**: *object*
+
+#### Type declaration:
+
+Defined in: [src/auth.tsx:87](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L87)
+
+___
+
+### startWithValue
+
+• `Optional` **startWithValue**: *any*
+
+**`deprecated`** use initialData instead
+
+Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[startWithValue](auth.signincheckoptionsbasic.md#startwithvalue)
+
+Defined in: [src/index.ts:16](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L16)
+
+___
+
+### suspense
+
+• `Optional` **suspense**: *boolean*
+
+Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[suspense](auth.signincheckoptionsbasic.md#suspense)
+
+Defined in: [src/index.ts:17](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L17)

--- a/docs/reference/interfaces/auth.signincheckoptionsclaimsobject.md
+++ b/docs/reference/interfaces/auth.signincheckoptionsclaimsobject.md
@@ -29,7 +29,7 @@
 
 Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[forceRefresh](auth.signincheckoptionsbasic.md#forcerefresh)
 
-Defined in: [src/auth.tsx:83](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L83)
+Defined in: [src/auth.tsx:84](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L84)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[idField](auth.signincheckoptionsbasic.md#idfield)
 
-Defined in: [src/index.ts:11](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L11)
+Defined in: [src/index.ts:23](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L23)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[initialData](auth.signincheckoptionsbasic.md#initialdata)
 
-Defined in: [src/index.ts:12](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L12)
+Defined in: [src/index.ts:24](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L24)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Type declaration:
 
-Defined in: [src/auth.tsx:87](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L87)
+Defined in: [src/auth.tsx:88](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L88)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[startWithValue](auth.signincheckoptionsbasic.md#startwithvalue)
 
-Defined in: [src/index.ts:16](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L16)
+Defined in: [src/index.ts:28](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L28)
 
 ___
 
@@ -81,4 +81,4 @@ ___
 
 Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[suspense](auth.signincheckoptionsbasic.md#suspense)
 
-Defined in: [src/index.ts:17](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L17)
+Defined in: [src/index.ts:29](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L29)

--- a/docs/reference/interfaces/auth.signincheckoptionsclaimsobject.md
+++ b/docs/reference/interfaces/auth.signincheckoptionsclaimsobject.md
@@ -29,7 +29,7 @@
 
 Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[forceRefresh](auth.signincheckoptionsbasic.md#forcerefresh)
 
-Defined in: [src/auth.tsx:84](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L84)
+Defined in: [src/auth.tsx:85](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L85)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Type declaration:
 
-Defined in: [src/auth.tsx:88](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L88)
+Defined in: [src/auth.tsx:89](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L89)
 
 ___
 

--- a/docs/reference/interfaces/auth.signincheckoptionsclaimsvalidator.md
+++ b/docs/reference/interfaces/auth.signincheckoptionsclaimsvalidator.md
@@ -29,7 +29,7 @@
 
 Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[forceRefresh](auth.signincheckoptionsbasic.md#forcerefresh)
 
-Defined in: [src/auth.tsx:83](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L83)
+Defined in: [src/auth.tsx:84](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L84)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[idField](auth.signincheckoptionsbasic.md#idfield)
 
-Defined in: [src/index.ts:11](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L11)
+Defined in: [src/index.ts:23](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L23)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[initialData](auth.signincheckoptionsbasic.md#initialdata)
 
-Defined in: [src/index.ts:12](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L12)
+Defined in: [src/index.ts:24](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L24)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[startWithValue](auth.signincheckoptionsbasic.md#startwithvalue)
 
-Defined in: [src/index.ts:16](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L16)
+Defined in: [src/index.ts:28](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L28)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[suspense](auth.signincheckoptionsbasic.md#suspense)
 
-Defined in: [src/index.ts:17](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L17)
+Defined in: [src/index.ts:29](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L29)
 
 ___
 
@@ -79,4 +79,4 @@ ___
 
 • **validateCustomClaims**: [*ClaimsValidator*](auth.claimsvalidator.md)
 
-Defined in: [src/auth.tsx:98](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L98)
+Defined in: [src/auth.tsx:99](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L99)

--- a/docs/reference/interfaces/auth.signincheckoptionsclaimsvalidator.md
+++ b/docs/reference/interfaces/auth.signincheckoptionsclaimsvalidator.md
@@ -1,0 +1,82 @@
+[ReactFire reference docs](../README.md) / [auth](../modules/auth.md) / SignInCheckOptionsClaimsValidator
+
+# Interface: SignInCheckOptionsClaimsValidator
+
+[auth](../modules/auth.md).SignInCheckOptionsClaimsValidator
+
+## Hierarchy
+
+* [*SignInCheckOptionsBasic*](auth.signincheckoptionsbasic.md)
+
+  ↳ **SignInCheckOptionsClaimsValidator**
+
+## Table of contents
+
+### Properties
+
+- [forceRefresh](auth.signincheckoptionsclaimsvalidator.md#forcerefresh)
+- [idField](auth.signincheckoptionsclaimsvalidator.md#idfield)
+- [initialData](auth.signincheckoptionsclaimsvalidator.md#initialdata)
+- [startWithValue](auth.signincheckoptionsclaimsvalidator.md#startwithvalue)
+- [suspense](auth.signincheckoptionsclaimsvalidator.md#suspense)
+- [validateCustomClaims](auth.signincheckoptionsclaimsvalidator.md#validatecustomclaims)
+
+## Properties
+
+### forceRefresh
+
+• `Optional` **forceRefresh**: *boolean*
+
+Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[forceRefresh](auth.signincheckoptionsbasic.md#forcerefresh)
+
+Defined in: [src/auth.tsx:83](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L83)
+
+___
+
+### idField
+
+• `Optional` **idField**: *string*
+
+Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[idField](auth.signincheckoptionsbasic.md#idfield)
+
+Defined in: [src/index.ts:11](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L11)
+
+___
+
+### initialData
+
+• `Optional` **initialData**: *any*
+
+Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[initialData](auth.signincheckoptionsbasic.md#initialdata)
+
+Defined in: [src/index.ts:12](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L12)
+
+___
+
+### startWithValue
+
+• `Optional` **startWithValue**: *any*
+
+**`deprecated`** use initialData instead
+
+Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[startWithValue](auth.signincheckoptionsbasic.md#startwithvalue)
+
+Defined in: [src/index.ts:16](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L16)
+
+___
+
+### suspense
+
+• `Optional` **suspense**: *boolean*
+
+Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[suspense](auth.signincheckoptionsbasic.md#suspense)
+
+Defined in: [src/index.ts:17](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L17)
+
+___
+
+### validateCustomClaims
+
+• **validateCustomClaims**: [*ClaimsValidator*](auth.claimsvalidator.md)
+
+Defined in: [src/auth.tsx:98](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L98)

--- a/docs/reference/interfaces/auth.signincheckoptionsclaimsvalidator.md
+++ b/docs/reference/interfaces/auth.signincheckoptionsclaimsvalidator.md
@@ -29,7 +29,7 @@
 
 Inherited from: [SignInCheckOptionsBasic](auth.signincheckoptionsbasic.md).[forceRefresh](auth.signincheckoptionsbasic.md#forcerefresh)
 
-Defined in: [src/auth.tsx:84](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L84)
+Defined in: [src/auth.tsx:85](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L85)
 
 ___
 
@@ -79,4 +79,4 @@ ___
 
 • **validateCustomClaims**: [*ClaimsValidator*](auth.claimsvalidator.md)
 
-Defined in: [src/auth.tsx:99](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L99)
+Defined in: [src/auth.tsx:100](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L100)

--- a/docs/reference/interfaces/index.reactfireoptions.md
+++ b/docs/reference/interfaces/index.reactfireoptions.md
@@ -10,6 +10,12 @@
 | :------ | :------ |
 | `T` | *unknown* |
 
+## Hierarchy
+
+* **ReactFireOptions**
+
+  ↳ [*SignInCheckOptions*](auth.signincheckoptions.md)
+
 ## Table of contents
 
 ### Properties

--- a/docs/reference/interfaces/index.reactfireoptions.md
+++ b/docs/reference/interfaces/index.reactfireoptions.md
@@ -14,7 +14,7 @@
 
 * **ReactFireOptions**
 
-  ↳ [*SignInCheckOptions*](auth.signincheckoptions.md)
+  ↳ [*SignInCheckOptionsBasic*](auth.signincheckoptionsbasic.md)
 
 ## Table of contents
 

--- a/docs/reference/interfaces/index.reactfireoptions.md
+++ b/docs/reference/interfaces/index.reactfireoptions.md
@@ -31,7 +31,7 @@
 
 • `Optional` **idField**: *string*
 
-Defined in: [src/index.ts:11](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L11)
+Defined in: [src/index.ts:23](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L23)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • `Optional` **initialData**: *any*
 
-Defined in: [src/index.ts:12](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L12)
+Defined in: [src/index.ts:24](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L24)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 **`deprecated`** use initialData instead
 
-Defined in: [src/index.ts:16](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L16)
+Defined in: [src/index.ts:28](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L28)
 
 ___
 
@@ -57,4 +57,4 @@ ___
 
 • `Optional` **suspense**: *boolean*
 
-Defined in: [src/index.ts:17](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L17)
+Defined in: [src/index.ts:29](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L29)

--- a/docs/reference/modules/auth.md
+++ b/docs/reference/modules/auth.md
@@ -7,6 +7,7 @@
 ### Interfaces
 
 - [AuthCheckProps](../interfaces/auth.authcheckprops.md)
+- [ClaimCheckErrors](../interfaces/auth.claimcheckerrors.md)
 - [ClaimsCheckProps](../interfaces/auth.claimscheckprops.md)
 - [ClaimsValidator](../interfaces/auth.claimsvalidator.md)
 - [SignInCheckOptionsBasic](../interfaces/auth.signincheckoptionsbasic.md)
@@ -30,7 +31,7 @@
 
 ### SigninCheckResult
 
-Ƭ **SigninCheckResult**: { `errors`: {} ; `hasRequiredClaims`: ``false`` ; `signedIn`: ``false`` ; `user`: ``null``  } \| { `errors`: ClaimCheckErrors ; `hasRequiredClaims`: *boolean* ; `signedIn`: ``true`` ; `user`: firebase.User  }
+Ƭ **SigninCheckResult**: { `errors`: {} ; `hasRequiredClaims`: ``false`` ; `signedIn`: ``false`` ; `user`: ``null``  } \| { `errors`: [*ClaimCheckErrors*](../interfaces/auth.claimcheckerrors.md) ; `hasRequiredClaims`: *boolean* ; `signedIn`: ``true`` ; `user`: firebase.User  }
 
 Defined in: [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L70)
 

--- a/docs/reference/modules/auth.md
+++ b/docs/reference/modules/auth.md
@@ -30,7 +30,7 @@
 
 ### SigninCheckResult
 
-Ƭ **SigninCheckResult**: { `hasRequiredClaims`: ``false`` ; `signedIn`: ``false``  } \| { `errors?`: ClaimCheckErrors ; `hasRequiredClaims`: *boolean* ; `signedIn`: ``true`` ; `user`: firebase.User  }
+Ƭ **SigninCheckResult**: { `errors`: {} ; `hasRequiredClaims`: ``false`` ; `signedIn`: ``false``  } \| { `errors`: ClaimCheckErrors ; `hasRequiredClaims`: *boolean* ; `signedIn`: ``true`` ; `user`: firebase.User  }
 
 Defined in: [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L70)
 
@@ -54,7 +54,7 @@ Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More 
 
 **Returns:** JSX.Element
 
-Defined in: [src/auth.tsx:223](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L223)
+Defined in: [src/auth.tsx:225](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L225)
 
 ___
 
@@ -76,7 +76,7 @@ Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More 
 
 **Returns:** *Element*
 
-Defined in: [src/auth.tsx:193](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L193)
+Defined in: [src/auth.tsx:195](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L195)
 
 ___
 
@@ -144,7 +144,7 @@ const {status, data: signInCheckResult} = useSignInCheck({forceRefresh: true, re
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<[*SigninCheckResult*](auth.md#signincheckresult)\>
 
-Defined in: [src/auth.tsx:119](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L119)
+Defined in: [src/auth.tsx:120](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L120)
 
 ___
 

--- a/docs/reference/modules/auth.md
+++ b/docs/reference/modules/auth.md
@@ -39,6 +39,10 @@ Defined in: [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob
 
 **`deprecated`** Use `useSignInCheck` instead
 
+Conditionally render children based on signed-in status and [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims).
+
+Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More detail](https://github.com/FirebaseExtended/reactfire/issues/325#issuecomment-827654376).
+
 #### Parameters:
 
 | Name | Type |
@@ -47,7 +51,7 @@ Defined in: [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob
 
 **Returns:** JSX.Element
 
-Defined in: [src/auth.tsx:186](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L186)
+Defined in: [src/auth.tsx:194](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L194)
 
 ___
 
@@ -57,6 +61,10 @@ ___
 
 **`deprecated`** Use `useSignInCheck` instead
 
+Conditionally render children based on [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims).
+
+Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More detail](https://github.com/FirebaseExtended/reactfire/issues/325#issuecomment-827654376).
+
 #### Parameters:
 
 | Name | Type |
@@ -65,7 +73,7 @@ ___
 
 **Returns:** *Element*
 
-Defined in: [src/auth.tsx:160](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L160)
+Defined in: [src/auth.tsx:164](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L164)
 
 ___
 

--- a/docs/reference/modules/auth.md
+++ b/docs/reference/modules/auth.md
@@ -132,7 +132,7 @@ const {status, data: signInCheckResult} = useSignInCheck({validateCustomClaims: 
   // custom validation logic...
 }});
 
-// You can optionally, force refresh the token
+// You can optionally force-refresh the token
 const {status, data: signInCheckResult} = useSignInCheck({forceRefresh: true, requiredClaims: {admin: true}});
 ```
 

--- a/docs/reference/modules/auth.md
+++ b/docs/reference/modules/auth.md
@@ -54,7 +54,7 @@ Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More 
 
 **Returns:** JSX.Element
 
-Defined in: [src/auth.tsx:225](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L225)
+Defined in: [src/auth.tsx:239](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L239)
 
 ___
 
@@ -76,7 +76,7 @@ Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More 
 
 **Returns:** *Element*
 
-Defined in: [src/auth.tsx:195](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L195)
+Defined in: [src/auth.tsx:209](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L209)
 
 ___
 
@@ -121,6 +121,19 @@ ___
 
 Subscribe to the signed-in status of a user.
 
+```ts
+const { status, data:signInCheckResult } = useSigninCheck();
+
+if (status === 'loading') {
+  return <LoadingSpinner />}
+
+if (signInCheckResult.signedIn === true) {
+  return <ProfilePage user={signInCheckResult.user}/>
+} else {
+  return <SignInForm />
+}
+```
+
 Optionally check [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims) of a user as well.
 
 ```ts
@@ -144,7 +157,7 @@ const {status, data: signInCheckResult} = useSignInCheck({forceRefresh: true, re
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<[*SigninCheckResult*](auth.md#signincheckresult)\>
 
-Defined in: [src/auth.tsx:120](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L120)
+Defined in: [src/auth.tsx:134](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L134)
 
 ___
 

--- a/docs/reference/modules/auth.md
+++ b/docs/reference/modules/auth.md
@@ -27,7 +27,7 @@
 
 ### SigninCheckResult
 
-Ƭ **SigninCheckResult**: { `hasRequiredClaims`: ``false`` ; `signedIn`: ``false``  } \| { `hasRequiredClaims`: *boolean* ; `missingClaims`: MissingClaims ; `signedIn`: ``true``  }
+Ƭ **SigninCheckResult**: { `hasRequiredClaims`: ``false`` ; `signedIn`: ``false``  } \| { `hasRequiredClaims`: *boolean* ; `missingClaims?`: MissingClaims ; `signedIn`: ``true`` ; `user`: firebase.User  }
 
 Defined in: [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L70)
 
@@ -51,7 +51,7 @@ Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More 
 
 **Returns:** JSX.Element
 
-Defined in: [src/auth.tsx:194](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L194)
+Defined in: [src/auth.tsx:199](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L199)
 
 ___
 
@@ -73,7 +73,7 @@ Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More 
 
 **Returns:** *Element*
 
-Defined in: [src/auth.tsx:164](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L164)
+Defined in: [src/auth.tsx:169](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L169)
 
 ___
 
@@ -163,7 +163,7 @@ function ProductPricesAdminPanel() {
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<[*SigninCheckResult*](auth.md#signincheckresult)\>
 
-Defined in: [src/auth.tsx:122](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L122)
+Defined in: [src/auth.tsx:127](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L127)
 
 ___
 

--- a/docs/reference/modules/auth.md
+++ b/docs/reference/modules/auth.md
@@ -8,7 +8,10 @@
 
 - [AuthCheckProps](../interfaces/auth.authcheckprops.md)
 - [ClaimsCheckProps](../interfaces/auth.claimscheckprops.md)
-- [SignInCheckOptions](../interfaces/auth.signincheckoptions.md)
+- [ClaimsValidator](../interfaces/auth.claimsvalidator.md)
+- [SignInCheckOptionsBasic](../interfaces/auth.signincheckoptionsbasic.md)
+- [SignInCheckOptionsClaimsObject](../interfaces/auth.signincheckoptionsclaimsobject.md)
+- [SignInCheckOptionsClaimsValidator](../interfaces/auth.signincheckoptionsclaimsvalidator.md)
 
 ### Type aliases
 
@@ -27,7 +30,7 @@
 
 ### SigninCheckResult
 
-Ƭ **SigninCheckResult**: { `hasRequiredClaims`: ``false`` ; `signedIn`: ``false``  } \| { `hasRequiredClaims`: *boolean* ; `missingClaims?`: MissingClaims ; `signedIn`: ``true`` ; `user`: firebase.User  }
+Ƭ **SigninCheckResult**: { `hasRequiredClaims`: ``false`` ; `signedIn`: ``false``  } \| { `errors?`: ClaimCheckErrors ; `hasRequiredClaims`: *boolean* ; `signedIn`: ``true`` ; `user`: firebase.User  }
 
 Defined in: [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L70)
 
@@ -51,7 +54,7 @@ Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More 
 
 **Returns:** JSX.Element
 
-Defined in: [src/auth.tsx:199](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L199)
+Defined in: [src/auth.tsx:223](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L223)
 
 ___
 
@@ -73,7 +76,7 @@ Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More 
 
 **Returns:** *Element*
 
-Defined in: [src/auth.tsx:169](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L169)
+Defined in: [src/auth.tsx:193](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L193)
 
 ___
 
@@ -114,56 +117,34 @@ ___
 
 ### useSigninCheck
 
-▸ **useSigninCheck**(`options?`: [*SignInCheckOptions*](../interfaces/auth.signincheckoptions.md)): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<[*SigninCheckResult*](auth.md#signincheckresult)\>
+▸ **useSigninCheck**(`options?`: [*SignInCheckOptionsBasic*](../interfaces/auth.signincheckoptionsbasic.md) \| [*SignInCheckOptionsClaimsObject*](../interfaces/auth.signincheckoptionsclaimsobject.md) \| [*SignInCheckOptionsClaimsValidator*](../interfaces/auth.signincheckoptionsclaimsvalidator.md)): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<[*SigninCheckResult*](auth.md#signincheckresult)\>
 
 Subscribe to the signed-in status of a user.
 
-Simple use case:
+Optionally check [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims) of a user as well.
 
-```jsx
-function UserFavorites() {
-   const {status, data: signInCheckResult} = useSigninCheck();
+```ts
+// pass in an object describing the custom claims a user must have
+const {status, data: signInCheckResult} = useSignInCheck({requiredClaims: {admin: true}});
 
-   if (status === 'loading') {
-     return <LoadingSpinner />
-   }
+// pass in a custom claims validator function
+const {status, data: signInCheckResult} = useSignInCheck({validateCustomClaims: (userClaims) => {
+  // custom validation logic...
+}});
 
-   if (signInCheckResult.signedIn === true) {
-     return <FavoritesList />
-   } else {
-     return <SignInForm />
-   }
-}
-```
-
-Advanced: You can also optionally check [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims). Example:
-
-```jsx
-function ProductPricesAdminPanel() {
-   const {status, data: signInCheckResult} = useSigninCheck({requiredClaims: {admin: true, canModifyPrices: true}});
-
-   if (status === 'loading') {
-     return <LoadingSpinner />
-   }
-
-   if (signInCheckResult.signedIn && signInCheckResult.hasRequiredClaims) {
-     return <FavoritesList />
-   } else {
-     console.warn('missing claims', signInCheckResult.missingClaims);
-     return <SignInForm />
-   }
-}
+// You can optionally, force refresh the token
+const {status, data: signInCheckResult} = useSignInCheck({forceRefresh: true, requiredClaims: {admin: true}});
 ```
 
 #### Parameters:
 
 | Name | Type |
 | :------ | :------ |
-| `options?` | [*SignInCheckOptions*](../interfaces/auth.signincheckoptions.md) |
+| `options?` | [*SignInCheckOptionsBasic*](../interfaces/auth.signincheckoptionsbasic.md) \| [*SignInCheckOptionsClaimsObject*](../interfaces/auth.signincheckoptionsclaimsobject.md) \| [*SignInCheckOptionsClaimsValidator*](../interfaces/auth.signincheckoptionsclaimsvalidator.md) |
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<[*SigninCheckResult*](auth.md#signincheckresult)\>
 
-Defined in: [src/auth.tsx:127](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L127)
+Defined in: [src/auth.tsx:119](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L119)
 
 ___
 

--- a/docs/reference/modules/auth.md
+++ b/docs/reference/modules/auth.md
@@ -30,7 +30,7 @@
 
 ### SigninCheckResult
 
-Ƭ **SigninCheckResult**: { `errors`: {} ; `hasRequiredClaims`: ``false`` ; `signedIn`: ``false``  } \| { `errors`: ClaimCheckErrors ; `hasRequiredClaims`: *boolean* ; `signedIn`: ``true`` ; `user`: firebase.User  }
+Ƭ **SigninCheckResult**: { `errors`: {} ; `hasRequiredClaims`: ``false`` ; `signedIn`: ``false`` ; `user`: ``null``  } \| { `errors`: ClaimCheckErrors ; `hasRequiredClaims`: *boolean* ; `signedIn`: ``true`` ; `user`: firebase.User  }
 
 Defined in: [src/auth.tsx:70](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L70)
 
@@ -54,7 +54,7 @@ Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More 
 
 **Returns:** JSX.Element
 
-Defined in: [src/auth.tsx:239](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L239)
+Defined in: [src/auth.tsx:240](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L240)
 
 ___
 
@@ -76,7 +76,7 @@ Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More 
 
 **Returns:** *Element*
 
-Defined in: [src/auth.tsx:209](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L209)
+Defined in: [src/auth.tsx:210](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L210)
 
 ___
 
@@ -157,7 +157,7 @@ const {status, data: signInCheckResult} = useSignInCheck({forceRefresh: true, re
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<[*SigninCheckResult*](auth.md#signincheckresult)\>
 
-Defined in: [src/auth.tsx:134](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L134)
+Defined in: [src/auth.tsx:135](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L135)
 
 ___
 

--- a/docs/reference/modules/auth.md
+++ b/docs/reference/modules/auth.md
@@ -8,6 +8,11 @@
 
 - [AuthCheckProps](../interfaces/auth.authcheckprops.md)
 - [ClaimsCheckProps](../interfaces/auth.claimscheckprops.md)
+- [SignInCheckOptions](../interfaces/auth.signincheckoptions.md)
+
+### Type aliases
+
+- [SigninCheckResult](auth.md#signincheckresult)
 
 ### Functions
 
@@ -15,13 +20,24 @@
 - [ClaimsCheck](auth.md#claimscheck)
 - [preloadUser](auth.md#preloaduser)
 - [useIdTokenResult](auth.md#useidtokenresult)
+- [useSigninCheck](auth.md#usesignincheck)
 - [useUser](auth.md#useuser)
+
+## Type aliases
+
+### SigninCheckResult
+
+Ƭ **SigninCheckResult**: { `hasRequiredClaims`: ``false`` ; `signedIn`: ``false``  } \| { `hasRequiredClaims`: *boolean* ; `missingClaims`: MissingClaims ; `signedIn`: ``true``  }
+
+Defined in: [src/auth.tsx:79](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L79)
 
 ## Functions
 
 ### AuthCheck
 
 ▸ **AuthCheck**(`__namedParameters`: [*AuthCheckProps*](../interfaces/auth.authcheckprops.md)): JSX.Element
+
+**`deprecated`** Use `useSignInCheck` instead
 
 #### Parameters:
 
@@ -31,13 +47,15 @@
 
 **Returns:** JSX.Element
 
-Defined in: [src/auth.tsx:97](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L97)
+Defined in: [src/auth.tsx:195](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L195)
 
 ___
 
 ### ClaimsCheck
 
 ▸ **ClaimsCheck**(`__namedParameters`: [*ClaimsCheckProps*](../interfaces/auth.claimscheckprops.md)): *Element*
+
+**`deprecated`** Use `useSignInCheck` instead
 
 #### Parameters:
 
@@ -47,7 +65,7 @@ ___
 
 **Returns:** *Element*
 
-Defined in: [src/auth.tsx:74](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L74)
+Defined in: [src/auth.tsx:169](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L169)
 
 ___
 
@@ -64,7 +82,7 @@ ___
 
 **Returns:** *Promise*<User\>
 
-Defined in: [src/auth.tsx:8](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L8)
+Defined in: [src/auth.tsx:9](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L9)
 
 ___
 
@@ -82,7 +100,62 @@ ___
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<firebase.auth.IdTokenResult\>
 
-Defined in: [src/auth.tsx:45](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L45)
+Defined in: [src/auth.tsx:46](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L46)
+
+___
+
+### useSigninCheck
+
+▸ **useSigninCheck**(`options?`: [*SignInCheckOptions*](../interfaces/auth.signincheckoptions.md)): [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<[*SigninCheckResult*](auth.md#signincheckresult)\>
+
+Subscribe to the signed-in status of a user.
+
+Simple use case:
+
+```jsx
+function UserFavorites() {
+   const {status, data: signInCheckResult} = useSigninCheck();
+
+   if (status === 'loading') {
+     return <LoadingSpinner />
+   }
+
+   if (signInCheckResult.signedIn === true) {
+     return <FavoritesList />
+   } else {
+     return <SignInForm />
+   }
+}
+```
+
+Advanced: You can also optionally check [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims). Example:
+
+```jsx
+function ProductPricesAdminPanel() {
+   const {status, data: signInCheckResult} = useSigninCheck({requiredClaims: {admin: true, canModifyPrices: true}});
+
+   if (status === 'loading') {
+     return <LoadingSpinner />
+   }
+
+   if (signInCheckResult.signedIn && signInCheckResult.hasRequiredClaims) {
+     return <FavoritesList />
+   } else {
+     console.warn('missing claims', signInCheckResult.missingClaims);
+     return <SignInForm />
+   }
+}
+```
+
+#### Parameters:
+
+| Name | Type |
+| :------ | :------ |
+| `options?` | [*SignInCheckOptions*](../interfaces/auth.signincheckoptions.md) |
+
+**Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<[*SigninCheckResult*](auth.md#signincheckresult)\>
+
+Defined in: [src/auth.tsx:131](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L131)
 
 ___
 
@@ -107,4 +180,4 @@ Subscribe to Firebase auth state changes, including token refresh
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<firebase.User\>
 
-Defined in: [src/auth.tsx:24](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L24)
+Defined in: [src/auth.tsx:25](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L25)

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -13,6 +13,8 @@
 - [FirebaseAppProvider](index.md#firebaseappprovider)
 - [ObservableStatus](index.md#observablestatus)
 - [PreloadOptions](index.md#preloadoptions)
+- [SignInCheckOptions](index.md#signincheckoptions)
+- [SigninCheckResult](index.md#signincheckresult)
 - [StorageImage](index.md#storageimage)
 - [SuspensePerfProps](index.md#suspenseperfprops)
 - [SuspenseWithPerf](index.md#suspensewithperf)
@@ -64,6 +66,7 @@
 - [useRemoteConfigNumber](index.md#useremoteconfignumber)
 - [useRemoteConfigString](index.md#useremoteconfigstring)
 - [useRemoteConfigValue](index.md#useremoteconfigvalue)
+- [useSigninCheck](index.md#usesignincheck)
 - [useStorage](index.md#usestorage)
 - [useStorageDownloadURL](index.md#usestoragedownloadurl)
 - [useStorageTask](index.md#usestoragetask)
@@ -126,6 +129,18 @@ ___
 ### PreloadOptions
 
 Re-exports: [PreloadOptions](sdk.md#preloadoptions)
+
+___
+
+### SignInCheckOptions
+
+Re-exports: [SignInCheckOptions](../interfaces/auth.signincheckoptions.md)
+
+___
+
+### SigninCheckResult
+
+Re-exports: [SigninCheckResult](auth.md#signincheckresult)
 
 ___
 
@@ -432,6 +447,12 @@ ___
 ### useRemoteConfigValue
 
 Re-exports: [useRemoteConfigValue](remote_config.md#useremoteconfigvalue)
+
+___
+
+### useSigninCheck
+
+Re-exports: [useSigninCheck](auth.md#usesignincheck)
 
 ___
 

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -10,10 +10,13 @@
 - [AuthCheckProps](index.md#authcheckprops)
 - [ClaimsCheck](index.md#claimscheck)
 - [ClaimsCheckProps](index.md#claimscheckprops)
+- [ClaimsValidator](index.md#claimsvalidator)
 - [FirebaseAppProvider](index.md#firebaseappprovider)
 - [ObservableStatus](index.md#observablestatus)
 - [PreloadOptions](index.md#preloadoptions)
-- [SignInCheckOptions](index.md#signincheckoptions)
+- [SignInCheckOptionsBasic](index.md#signincheckoptionsbasic)
+- [SignInCheckOptionsClaimsObject](index.md#signincheckoptionsclaimsobject)
+- [SignInCheckOptionsClaimsValidator](index.md#signincheckoptionsclaimsvalidator)
 - [SigninCheckResult](index.md#signincheckresult)
 - [StorageImage](index.md#storageimage)
 - [SuspensePerfProps](index.md#suspenseperfprops)
@@ -114,6 +117,12 @@ Re-exports: [ClaimsCheckProps](../interfaces/auth.claimscheckprops.md)
 
 ___
 
+### ClaimsValidator
+
+Re-exports: [ClaimsValidator](../interfaces/auth.claimsvalidator.md)
+
+___
+
 ### FirebaseAppProvider
 
 Re-exports: [FirebaseAppProvider](firebaseapp.md#firebaseappprovider)
@@ -132,9 +141,21 @@ Re-exports: [PreloadOptions](sdk.md#preloadoptions)
 
 ___
 
-### SignInCheckOptions
+### SignInCheckOptionsBasic
 
-Re-exports: [SignInCheckOptions](../interfaces/auth.signincheckoptions.md)
+Re-exports: [SignInCheckOptionsBasic](../interfaces/auth.signincheckoptionsbasic.md)
+
+___
+
+### SignInCheckOptionsClaimsObject
+
+Re-exports: [SignInCheckOptionsClaimsObject](../interfaces/auth.signincheckoptionsclaimsobject.md)
+
+___
+
+### SignInCheckOptionsClaimsValidator
+
+Re-exports: [SignInCheckOptionsClaimsValidator](../interfaces/auth.signincheckoptionsclaimsvalidator.md)
 
 ___
 

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -77,6 +77,10 @@
 - [useUser](index.md#useuser)
 - [version](index.md#version)
 
+### Classes
+
+- [ReactFireError](../classes/index.reactfireerror.md)
+
 ### Interfaces
 
 - [ReactFireOptions](../interfaces/index.reactfireoptions.md)
@@ -541,7 +545,7 @@ Defined in: [src/index.ts:4](https://github.com/FirebaseExtended/reactfire/blob/
 
 **Returns:** *any*
 
-Defined in: [src/index.ts:33](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L33)
+Defined in: [src/index.ts:45](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L45)
 
 ___
 
@@ -558,7 +562,7 @@ ___
 
 **Returns:** *any*
 
-Defined in: [src/index.ts:20](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L20)
+Defined in: [src/index.ts:32](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L32)
 
 ___
 
@@ -574,4 +578,4 @@ ___
 
 **Returns:** *any*
 
-Defined in: [src/index.ts:29](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L29)
+Defined in: [src/index.ts:41](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L41)

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -8,6 +8,7 @@
 
 - [AuthCheck](index.md#authcheck)
 - [AuthCheckProps](index.md#authcheckprops)
+- [ClaimCheckErrors](index.md#claimcheckerrors)
 - [ClaimsCheck](index.md#claimscheck)
 - [ClaimsCheckProps](index.md#claimscheckprops)
 - [ClaimsValidator](index.md#claimsvalidator)
@@ -106,6 +107,12 @@ ___
 ### AuthCheckProps
 
 Re-exports: [AuthCheckProps](../interfaces/auth.authcheckprops.md)
+
+___
+
+### ClaimCheckErrors
+
+Re-exports: [ClaimCheckErrors](../interfaces/auth.claimcheckerrors.md)
 
 ___
 

--- a/docs/use.md
+++ b/docs/use.md
@@ -62,14 +62,22 @@ Note: `useUser` will also automatically lazily import the `firebase/auth` SDK if
 
 ### Decide what to render based on a user's auth state
 
-The `AuthCheck` component makes it easy to hide/show UI elements based on a user's auth state. It will render its children if a user is signed in, but if they are not signed in, it renders its `fallback` prop:
+The `useSignInCheck` hook makes it easy to decide whether to hide or show UI elements based on a user's auth state, and even their [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims). It will render its children if a user is signed in, but if they are not signed in, it renders its `fallback` prop:
 
 ```jsx
-render(
-  <AuthCheck fallback={<LoginPage />}>
-    <HomePage />
-  </AuthCheck>
-);
+function UserFavorites() {
+  const { status, data: signInCheckResult } = useSigninCheck();
+
+  if (status === 'loading') {
+    return <LoadingSpinner />;
+  }
+
+  if (signInCheckResult.signedIn === true) {
+    return <FavoritesList />;
+  } else {
+    return <SignInForm />;
+  }
+}
 ```
 
 ## Log Page Views to Google Analytics for Firebase with React Router

--- a/example/withoutSuspense/Auth.tsx
+++ b/example/withoutSuspense/Auth.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth';
-import { useAuth, useUser } from 'reactfire';
+import { useAuth, useSigninCheck } from 'reactfire';
 import { WideButton } from '../display/Button';
 import { CardSection } from '../display/Card';
 import { LoadingSpinner } from '../display/LoadingSpinner';
@@ -8,14 +8,14 @@ import { LoadingSpinner } from '../display/LoadingSpinner';
 const signOut = auth => auth.signOut().then(() => console.log('signed out'));
 
 export const AuthWrapper = ({ children, fallback }: React.PropsWithChildren<{ fallback: JSX.Element }>): JSX.Element => {
-  const { status, data: user, hasEmitted } = useUser();
+  const { status, data: signInCheckResult } = useSigninCheck();
 
   if (!children) {
     throw new Error('Children must be provided');
   }
-  if (status === 'loading' || hasEmitted === false) {
+  if (status === 'loading') {
     return <LoadingSpinner />;
-  } else if (user) {
+  } else if (signInCheckResult.signedIn === true) {
     return children as JSX.Element;
   }
 
@@ -30,8 +30,8 @@ const UserDetails = ({ user }) => {
       <CardSection title="Displayname">{user.displayName}</CardSection>
       <CardSection title="Providers">
         <ul>
-          {user.providerData.map(profile => (
-            <li key={profile.providerId}>{profile.providerId}</li>
+          {user.providerData?.map(profile => (
+            <li key={profile?.providerId}>{profile?.providerId}</li>
           ))}
         </ul>
       </CardSection>
@@ -62,11 +62,17 @@ const SignInForm = () => {
 };
 
 export const Auth = () => {
-  const { status, data: user, hasEmitted } = useUser();
+  const { status, data: signinResult } = useSigninCheck();
 
-  if (status === 'loading' || hasEmitted === false) {
+  if (status === 'loading') {
     return <LoadingSpinner />;
   }
 
-  return user ? <UserDetails user={user} /> : <SignInForm />;
+  const { signedIn, user } = signinResult;
+
+  if (signedIn === true) {
+    return <UserDetails user={user} />;
+  } else {
+    return <SignInForm />;
+  }
 };

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@types/react-dom": "^16.9.8",
     "babel-jest": "^26.6.3",
     "firebase": "^8.1.1",
+    "firebase-admin": "^9.7.0",
     "firebase-tools": "^9.10.0",
     "globalthis": "^1.0.1",
     "husky": "^4.3.0",

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -64,7 +64,7 @@ export interface ClaimsCheckProps {
 }
 
 interface ClaimCheckErrors {
-  [key: string]: ReactFireError[];
+  [key: string]: any[];
 }
 
 export type SigninCheckResult =

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -63,7 +63,7 @@ export interface ClaimsCheckProps {
   requiredClaims: { [key: string]: any };
 }
 
-interface ClaimCheckErrors {
+export interface ClaimCheckErrors {
   [key: string]: any[];
 }
 

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -156,6 +156,10 @@ export function useSigninCheck(options?: SignInCheckOptions): ObservableStatus<S
 
 /**
  * @deprecated Use `useSignInCheck` instead
+ *
+ * Conditionally render children based on [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims).
+ *
+ * Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More detail](https://github.com/FirebaseExtended/reactfire/issues/325#issuecomment-827654376).
  */
 export function ClaimsCheck({ user, fallback, children, requiredClaims }: ClaimsCheckProps) {
   const { data } = useIdTokenResult(user, false);
@@ -182,6 +186,10 @@ export function ClaimsCheck({ user, fallback, children, requiredClaims }: Claims
 
 /**
  * @deprecated Use `useSignInCheck` instead
+ *
+ * Conditionally render children based on signed-in status and [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims).
+ *
+ * Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More detail](https://github.com/FirebaseExtended/reactfire/issues/325#issuecomment-827654376).
  */
 export function AuthCheck({ fallback, children, requiredClaims }: AuthCheckProps): JSX.Element {
   const { data: user } = useUser<firebase.User>();

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -72,6 +72,7 @@ export type SigninCheckResult =
       signedIn: false;
       hasRequiredClaims: false;
       errors: {};
+      user: null;
     }
   | {
       signedIn: true;

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -91,7 +91,7 @@ export interface SignInCheckOptionsClaimsObject extends SignInCheckOptionsBasic 
 export interface ClaimsValidator {
   (claims: firebase.auth.IdTokenResult['claims']): {
     hasRequiredClaims: boolean;
-    errors?: ClaimCheckErrors;
+    errors: ClaimCheckErrors | {};
   };
 }
 

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -146,7 +146,7 @@ export function useSigninCheck(options?: SignInCheckOptions): ObservableStatus<S
           })
         );
       } else {
-        return of({ signedIn: true });
+        return of({ signedIn: true, hasRequiredClaims: true });
       }
     })
   );

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -72,7 +72,12 @@ export type SigninCheckResult =
       signedIn: false;
       hasRequiredClaims: false;
     }
-  | { signedIn: true; hasRequiredClaims: boolean; missingClaims: MissingClaims };
+  | {
+      signedIn: true;
+      hasRequiredClaims: boolean;
+      missingClaims?: MissingClaims;
+      user: firebase.User;
+    };
 
 export interface SignInCheckOptions extends ReactFireOptions<SigninCheckResult> {
   requiredClaims?: { [key: string]: any };
@@ -122,7 +127,7 @@ export interface SignInCheckOptions extends ReactFireOptions<SigninCheckResult> 
 export function useSigninCheck(options?: SignInCheckOptions): ObservableStatus<SigninCheckResult> {
   const auth = useAuth();
 
-  const observableId = `auth:signInCheck:${auth.app.name}:requiredClaims:${JSON.stringify(options?.requiredClaims)}`;
+  const observableId = `auth:signInCheck:${auth.app.name}:requiredClaims:${JSON.stringify(options?.requiredClaims)}:forceRefresh:${!!options?.forceRefresh}`;
   const observable = user(auth).pipe(
     switchMap(user => {
       if (!user) {
@@ -142,11 +147,11 @@ export function useSigninCheck(options?: SignInCheckOptions): ObservableStatus<S
               }
             });
 
-            return { signedIn: true, hasRequiredClaims: Object.keys(missingClaims).length === 0, missingClaims };
+            return { signedIn: true, hasRequiredClaims: Object.keys(missingClaims).length === 0, missingClaims, user: user };
           })
         );
       } else {
-        return of({ signedIn: true, hasRequiredClaims: true });
+        return of({ signedIn: true, hasRequiredClaims: true, user: user });
       }
     })
   );

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -112,25 +112,25 @@ export interface SignInCheckOptionsClaimsValidator extends SignInCheckOptionsBas
  *   // custom validation logic...
  * }});
  *
- * // You can optionally, force refresh the token
+ * // You can optionally force-refresh the token
  * const {status, data: signInCheckResult} = useSignInCheck({forceRefresh: true, requiredClaims: {admin: true}});
  * ```
  */
 export function useSigninCheck(
   options?: SignInCheckOptionsBasic | SignInCheckOptionsClaimsObject | SignInCheckOptionsClaimsValidator
 ): ObservableStatus<SigninCheckResult> {
-  const auth = useAuth();
-
+  // If both `requiredClaims` and `validateClaims` are provided, we won't know which one to use
   if (options?.hasOwnProperty('requiredClaims') && options?.hasOwnProperty('validateClaims')) {
     throw new Error('Cannot have both "requiredClaims" and "validateClaims". Use one or the other.');
   }
 
-  let observableId = `auth:signInCheck:${auth.app.name}::forceRefresh:${!!options?.forceRefresh}`;
+  const auth = useAuth();
 
+  // ObservableId should change for different options configurations to ensure no cache collisions
+  let observableId = `auth:signInCheck:${auth.app.name}::forceRefresh:${!!options?.forceRefresh}`;
   if (options?.forceRefresh) {
     observableId = `${observableId}:forceRefresh:${options.forceRefresh}`;
   }
-
   if (options?.hasOwnProperty('requiredClaims')) {
     observableId = `${observableId}:requiredClaims:${JSON.stringify((options as SignInCheckOptionsClaimsObject).requiredClaims)}`;
   } else if (options?.hasOwnProperty('validateCustomClaims')) {
@@ -153,11 +153,11 @@ export function useSigninCheck(
             }
 
             const { hasRequiredClaims, errors } = validator(idTokenResult.claims);
-
             return { signedIn: true, hasRequiredClaims, errors, user: user };
           })
         );
       } else {
+        // If no claims are provided to be checked, `hasRequiredClaims` is true
         return of({ signedIn: true, hasRequiredClaims: true, user: user });
       }
     })

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -102,6 +102,20 @@ export interface SignInCheckOptionsClaimsValidator extends SignInCheckOptionsBas
 /**
  * Subscribe to the signed-in status of a user.
  *
+ * ```ts
+ * const { status, data:signInCheckResult } = useSigninCheck();
+ *
+ * if (status === 'loading') {
+ *   return <LoadingSpinner />}
+ *
+ *
+ * if (signInCheckResult.signedIn === true) {
+ *   return <ProfilePage user={signInCheckResult.user}/>
+ * } else {
+ *   return <SignInForm />
+ * }
+ * ```
+ *
  * Optionally check [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims) of a user as well.
  *
  * ```ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,18 @@ export type ReactFireGlobals = {
   _reactFirePreloadedObservables: Map<string, SuspenseSubject<any>>;
 };
 
+export class ReactFireError extends Error {
+  readonly name = 'ReactFireError';
+
+  constructor(readonly code: string, message: string, public customData?: Record<string, unknown>) {
+    super(message);
+
+    // Fix For ES5
+    // https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, ReactFireError.prototype);
+  }
+}
+
 export interface ReactFireOptions<T = unknown> {
   idField?: string;
   initialData?: T | any;

--- a/test/auth.test.tsx
+++ b/test/auth.test.tsx
@@ -159,7 +159,7 @@ describe('Authentication', () => {
         disabled: false
       });
 
-      expect(userRecord.uid).toBeTruthy;
+      expect(userRecord.uid).toBeTruthy();
 
       const customClaims = { canModifyPages: true, moderator: true };
 

--- a/test/auth.test.tsx
+++ b/test/auth.test.tsx
@@ -143,7 +143,7 @@ describe('Authentication', () => {
 
       // Signed in
       expect(app.auth().currentUser).not.toBeNull();
-      expect(result.current.data).toEqual({ signedIn: true, hasRequiredClaims: true });
+      expect(result.current.data).toEqual({ signedIn: true, hasRequiredClaims: true, user: app.auth().currentUser });
     });
 
     // Skipping this because of an issue setting custom claims

--- a/yarn.lock
+++ b/yarn.lock
@@ -914,6 +914,11 @@
     "@firebase/util" "1.0.0"
     tslib "^2.1.0"
 
+"@firebase/app-types@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.6.1.tgz#dcbd23030a71c0c74fc95d4a3f75ba81653850e9"
+  integrity sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg==
+
 "@firebase/app-types@0.6.2":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.6.2.tgz#8578cb1061a83ced4570188be9e225d54e0f27fb"
@@ -932,6 +937,11 @@
     tslib "^2.1.0"
     xmlhttprequest "1.8.0"
 
+"@firebase/auth-interop-types@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz#9fc9bd7c879f16b8d1bb08373a0f48c3a8b74557"
+  integrity sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==
+
 "@firebase/auth-interop-types@0.1.6":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz#5ce13fc1c527ad36f1bb1322c4492680a6cf4964"
@@ -949,6 +959,14 @@
   dependencies:
     "@firebase/auth-types" "0.10.3"
 
+"@firebase/component@0.1.21":
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/@firebase/component/-/component-0.1.21.tgz#56062eb0d449dc1e7bbef3c084a9b5fa48c7c14d"
+  integrity sha512-kd5sVmCLB95EK81Pj+yDTea8pzN2qo/1yr0ua9yVi6UgMzm6zAeih73iVUkaat96MAHy26yosMufkvd3zC4IKg==
+  dependencies:
+    "@firebase/util" "0.3.4"
+    tslib "^1.11.1"
+
 "@firebase/component@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@firebase/component/-/component-0.4.1.tgz#c8269f21149a4c81e385531428ad4c086a8f47db"
@@ -956,6 +974,13 @@
   dependencies:
     "@firebase/util" "1.0.0"
     tslib "^2.1.0"
+
+"@firebase/database-types@0.6.1", "@firebase/database-types@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-0.6.1.tgz#cf1cfc03e617ed4c2561703781f85ba4c707ff65"
+  integrity sha512-JtL3FUbWG+bM59iYuphfx9WOu2Mzf0OZNaqWiQ7lJR8wBe7bS9rIm9jlBFtksB7xcya1lZSQPA/GAy2jIlMIkA==
+  dependencies:
+    "@firebase/app-types" "0.6.1"
 
 "@firebase/database-types@0.7.2":
   version "0.7.2"
@@ -976,6 +1001,19 @@
     "@firebase/util" "1.0.0"
     faye-websocket "0.11.3"
     tslib "^2.1.0"
+
+"@firebase/database@^0.8.1":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-0.8.3.tgz#4e5efa8fc8df00d6febfd9c8d6d6e409596659f7"
+  integrity sha512-i29rr3kcPltIkA8La9M1lgsSxx9bfu5lCQ0T+tbJptZ3UpqpcL1NzCcZa24cJjiLgq3HQNPyLvUvCtcPSFDlRg==
+  dependencies:
+    "@firebase/auth-interop-types" "0.1.5"
+    "@firebase/component" "0.1.21"
+    "@firebase/database-types" "0.6.1"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "0.3.4"
+    faye-websocket "0.11.3"
+    tslib "^1.11.1"
 
 "@firebase/firestore-types@2.2.0":
   version "2.2.0"
@@ -1109,6 +1147,13 @@
     "@firebase/util" "1.0.0"
     tslib "^2.1.0"
 
+"@firebase/util@0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@firebase/util/-/util-0.3.4.tgz#e389d0e0e2aac88a5235b06ba9431db999d4892b"
+  integrity sha512-VwjJUE2Vgr2UMfH63ZtIX9Hd7x+6gayi6RUXaTqEYxSbf/JmehLmAEYSuxS/NckfzAXWeGnKclvnXVibDgpjQQ==
+  dependencies:
+    tslib "^1.11.1"
+
 "@firebase/util@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@firebase/util/-/util-1.0.0.tgz#cbe8ec610a84a7d2fc804af31010305941f4a34b"
@@ -1120,6 +1165,31 @@
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.1.tgz#600f2275ff54739ad5ac0102f1467b8963cd5f71"
   integrity sha512-0yPjzuzGMkW1GkrC8yWsiN7vt1OzkMIi9HgxRmKREZl2wnNPOKo/yScTjXf/O57HM8dltqxPF6jlNLFVtc2qdw==
+
+"@google-cloud/common@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-3.6.0.tgz#c2f6da5f79279a4a9ac7c71fc02d582beab98e8b"
+  integrity sha512-aHIFTqJZmeTNO9md8XxV+ywuvXF3xBm5WNmgWeeCK+XN5X+kGW0WEX94wGwj+/MdOnrVf4dL2RvSIt9J5yJG6Q==
+  dependencies:
+    "@google-cloud/projectify" "^2.0.0"
+    "@google-cloud/promisify" "^2.0.0"
+    arrify "^2.0.1"
+    duplexify "^4.1.1"
+    ent "^2.2.0"
+    extend "^3.0.2"
+    google-auth-library "^7.0.2"
+    retry-request "^4.1.1"
+    teeny-request "^7.0.0"
+
+"@google-cloud/firestore@^4.5.0":
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@google-cloud/firestore/-/firestore-4.10.1.tgz#674c7871558b1666dce3a624faa96c266214eabf"
+  integrity sha512-TwjnwIiS+j4Eb1+H4mT2afehBBl9VE49NdVjP7NvLXnKQ522zrqBg9J0GnUv0VENUKsPfhjn02QuuUizTHC6Dw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    functional-red-black-tree "^1.0.1"
+    google-gax "^2.9.2"
+    protobufjs "^6.8.6"
 
 "@google-cloud/paginator@^3.0.0":
   version "3.0.5"
@@ -1164,6 +1234,33 @@
     is-stream-ended "^0.1.4"
     lodash.snakecase "^4.1.1"
     p-defer "^3.0.0"
+
+"@google-cloud/storage@^5.3.0":
+  version "5.8.4"
+  resolved "https://registry.yarnpkg.com/@google-cloud/storage/-/storage-5.8.4.tgz#bca33d377c94bcafaf49c96b8122a45a22493dbc"
+  integrity sha512-jtEQZ0k6EkoQEkMpisjdEFOGqQiE9rRmJo6lhfLnGVfkV5dGg1BS70wEJ8jGm3AwxOwU86bYIMHkwtAGktbAfQ==
+  dependencies:
+    "@google-cloud/common" "^3.6.0"
+    "@google-cloud/paginator" "^3.0.0"
+    "@google-cloud/promisify" "^2.0.0"
+    arrify "^2.0.0"
+    async-retry "^1.3.1"
+    compressible "^2.0.12"
+    date-and-time "^1.0.0"
+    duplexify "^4.0.0"
+    extend "^3.0.2"
+    gaxios "^4.0.0"
+    gcs-resumable-upload "^3.1.3"
+    get-stream "^6.0.0"
+    hash-stream-validation "^0.2.2"
+    mime "^2.2.0"
+    mime-types "^2.0.8"
+    onetime "^5.1.0"
+    p-limit "^3.0.1"
+    pumpify "^2.0.0"
+    snakeize "^0.1.0"
+    stream-events "^1.0.1"
+    xdg-basedir "^4.0.0"
 
 "@grpc/grpc-js@^1.0.0", "@grpc/grpc-js@~1.2.0":
   version "1.2.12"
@@ -1820,6 +1917,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.1.tgz#ef34dea0881028d11398be5bf4e856743e3dc35a"
   integrity sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==
 
+"@types/node@^10.10.0":
+  version "10.17.59"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.59.tgz#03f440ccf746a27f7da6e141e6cbae64681dbd2f"
+  integrity sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg==
+
 "@types/node@^13.7.0":
   version "13.13.51"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.51.tgz#a424c5282f99fc1ca41f11b727b6aea80668bcba"
@@ -2437,7 +2539,7 @@ array.prototype.flatmap@^1.2.4:
     es-abstract "^1.18.0-next.1"
     function-bind "^1.1.1"
 
-arrify@^2.0.0:
+arrify@^2.0.0, arrify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
@@ -2512,6 +2614,13 @@ async-each@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
+
+async-retry@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.1.tgz#139f31f8ddce50c0870b0ba558a6079684aaed55"
+  integrity sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==
+  dependencies:
+    retry "0.12.0"
 
 async@^1.3.0:
   version "1.5.2"
@@ -3569,7 +3678,7 @@ compress-commons@^4.1.0:
     normalize-path "^3.0.0"
     readable-stream "^3.6.0"
 
-compressible@~2.0.16:
+compressible@^2.0.12, compressible@~2.0.16:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
   integrity sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==
@@ -3604,7 +3713,7 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-configstore@^5.0.1:
+configstore@^5.0.0, configstore@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-5.0.1.tgz#d365021b5df4b98cdd187d6a3b0e3f6a7cc5ed96"
   integrity sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==
@@ -4084,6 +4193,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-and-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-1.0.0.tgz#0062394bdf6f44e961f0db00511cb19cdf3cc0a5"
+  integrity sha512-477D7ypIiqlXBkxhU7YtG9wWZJEQ+RUpujt2quTfgf4+E8g5fNUkB0QIL0bVyP5/TKBg8y55Hfa1R/c4bt3dEw==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -4235,6 +4349,13 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+dicer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.3.0.tgz#eacd98b3bfbf92e8ab5c2fdb71aaac44bb06b872"
+  integrity sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==
+  dependencies:
+    streamsearch "0.1.2"
+
 diff-sequences@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
@@ -4370,7 +4491,7 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-duplexify@^4.0.0:
+duplexify@^4.0.0, duplexify@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.1.tgz#7027dc374f157b122a8ae08c2d3ea4d2d953aa61"
   integrity sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==
@@ -4475,6 +4596,11 @@ enquirer@^2.3.4:
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
+
+ent@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
+  integrity sha1-6WQhkyWiHQX0RGai9obtbOX13R0=
 
 entities@^2.0.0:
   version "2.2.0"
@@ -5303,6 +5429,21 @@ find-versions@^4.0.0:
   dependencies:
     semver-regex "^3.1.2"
 
+firebase-admin@^9.7.0:
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-9.7.0.tgz#c5fde178a1f1e757373b38601eb62a8ccbcb9393"
+  integrity sha512-dvxy4lK2P2BikE9lB2hj4dUXGm9tuoGRVtobXzCpk7uhi0/FuTOU1yp4IW7vlMI20fxTdm6FmCXdwUlMeSljBA==
+  dependencies:
+    "@firebase/database" "^0.8.1"
+    "@firebase/database-types" "^0.6.1"
+    "@types/node" "^10.10.0"
+    dicer "^0.3.0"
+    jsonwebtoken "^8.5.1"
+    node-forge "^0.10.0"
+  optionalDependencies:
+    "@google-cloud/firestore" "^4.5.0"
+    "@google-cloud/storage" "^5.3.0"
+
 firebase-tools@^9.10.0:
   version "9.10.0"
   resolved "https://registry.yarnpkg.com/firebase-tools/-/firebase-tools-9.10.0.tgz#59fbdeb472188fadf38e5c8bf680ac67b4216a34"
@@ -5613,6 +5754,19 @@ gcp-metadata@^4.2.0:
     gaxios "^4.0.0"
     json-bigint "^1.0.0"
 
+gcs-resumable-upload@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/gcs-resumable-upload/-/gcs-resumable-upload-3.1.3.tgz#1e38e1339600b85812e6430a5ab455453c64cce3"
+  integrity sha512-LjVrv6YVH0XqBr/iBW0JgRA1ndxhK6zfEFFJR4im51QVTj/4sInOXimY2evDZuSZ75D3bHxTaQAdXRukMc1y+w==
+  dependencies:
+    abort-controller "^3.0.0"
+    configstore "^5.0.0"
+    extend "^3.0.2"
+    gaxios "^4.0.0"
+    google-auth-library "^7.0.0"
+    pumpify "^2.0.0"
+    stream-events "^1.0.4"
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -5655,6 +5809,11 @@ get-stream@^5.0.0, get-stream@^5.1.0:
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
+
+get-stream@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 get-uri@3:
   version "3.0.2"
@@ -5979,6 +6138,11 @@ hash-base@^3.0.0:
     inherits "^2.0.4"
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
+
+hash-stream-validation@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz#ee68b41bf822f7f44db1142ec28ba9ee7ccb7512"
+  integrity sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ==
 
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
@@ -8039,7 +8203,7 @@ mime-db@1.47.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.47.0.tgz#8cb313e59965d3c05cfbf898915a267af46a335c"
   integrity sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
 
-mime-types@^2.1.12, mime-types@^2.1.16, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.0.8, mime-types@^2.1.12, mime-types@^2.1.16, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.30"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.30.tgz#6e7be8b4c479825f85ed6326695db73f9305d62d"
   integrity sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
@@ -8051,7 +8215,7 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.3.1, mime@^2.5.2:
+mime@^2.2.0, mime@^2.3.1, mime@^2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
@@ -8737,7 +8901,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
+p-limit@^3.0.1, p-limit@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -9575,6 +9739,15 @@ pumpify@^1.3.3:
     inherits "^2.0.3"
     pump "^2.0.0"
 
+pumpify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-2.0.1.tgz#abfc7b5a621307c728b551decbbefb51f0e4aa1e"
+  integrity sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==
+  dependencies:
+    duplexify "^4.1.1"
+    inherits "^2.0.3"
+    pump "^3.0.0"
+
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
@@ -10095,12 +10268,17 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-retry-request@^4.0.0:
+retry-request@^4.0.0, retry-request@^4.1.1:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-4.1.3.tgz#d5f74daf261372cff58d08b0a1979b4d7cab0fde"
   integrity sha512-QnRZUpuPNgX0+D1xVxul6DbJ9slvo4Rm6iV/dn63e048MvGbUZiKySVt6Tenp04JqmchxjiLltGerOJys7kJYQ==
   dependencies:
     debug "^4.1.1"
+
+retry@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -10560,6 +10738,11 @@ smart-buffer@^4.1.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
   integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
 
+snakeize@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/snakeize/-/snakeize-0.1.0.tgz#10c088d8b58eb076b3229bb5a04e232ce126422d"
+  integrity sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0=
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -10782,6 +10965,13 @@ stream-each@^1.1.0:
     end-of-stream "^1.1.0"
     stream-shift "^1.0.0"
 
+stream-events@^1.0.1, stream-events@^1.0.4, stream-events@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/stream-events/-/stream-events-1.0.5.tgz#bbc898ec4df33a4902d892333d47da9bf1c406d5"
+  integrity sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==
+  dependencies:
+    stubs "^3.0.0"
+
 stream-http@^2.7.2:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
@@ -10797,6 +10987,11 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+streamsearch@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
+  integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
 
 string-length@^1.0.0:
   version "1.0.1"
@@ -10968,6 +11163,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+stubs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
+  integrity sha1-6NK6H6nJBXAwPAMLaQD31fiavls=
 
 style-loader@^2.0.0:
   version "2.0.0"
@@ -11142,6 +11342,17 @@ tcp-port-used@^1.0.1:
   dependencies:
     debug "4.3.1"
     is2 "^2.0.6"
+
+teeny-request@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-7.0.1.tgz#bdd41fdffea5f8fbc0d29392cb47bec4f66b2b4c"
+  integrity sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==
+  dependencies:
+    http-proxy-agent "^4.0.0"
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.1"
+    stream-events "^1.0.5"
+    uuid "^8.0.0"
 
 term-size@^2.1.0:
   version "2.2.1"
@@ -11836,7 +12047,7 @@ uuid@^3.0.0, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.0.0, uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
Fixes #325 

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Deprecate `AuthCheck` and `ClaimsCheck` in favor of a hook that would allow easy implementation of either of those components: **`useSigninCheck()`**

### Code sample

Simple use case:

```jsx
function UserFavorites() {
   const {status, data: signInCheckResult} = useSigninCheck();

   if (status === 'loading') {
     return <LoadingSpinner />
   }

   if (signInCheckResult.signedIn === true) {
     return <FavoritesList />
   } else {
     return <SignInForm />
   }
}
```

Advanced: You can also optionally check [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims). Example:

```jsx
function ProductPricesAdminPanel() {
  const { status, data: signInCheckResult } = useSigninCheck({
    requiredClaims: { admin: true, canModifyPrices: true },
  });

  if (status === "loading") {
    return <LoadingSpinner />;
  }

  if (signInCheckResult.signedIn && signInCheckResult.hasRequiredClaims) {
    return <FavoritesList />;
  } else {
    console.warn(
      `User ${signInCheckResult.user.displayname} is missing claims:`,
      Object.keys(signInCheckResult.errors)
    );
    return <SignInForm />;
  }
}
```

### Why deprecate `AuthCheck` and `ClaimsCheck`?

They worked well in the previous version of ReactFire when ReactFire only supported concurrent mode, but are awkward now that we support both concurrent mode and non-concurrent mode (added in https://github.com/FirebaseExtended/reactfire/pull/255). Moving to a hook allows for the same easy checks, but leaves loading states to the developer, instead of `AuthCheck` and `ClaimsCheck` trying to handle both concurrent mode and non-concurrent mode loading strategies.