### PR TITLE
Set `hasEmitted` for `initialData`

### DIFF
--- a/docs/reference/interfaces/useobservable.observablestatus.md
+++ b/docs/reference/interfaces/useobservable.observablestatus.md
@@ -27,7 +27,11 @@
 
 • **data**: T
 
-Defined in: [src/useObservable.ts:36](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L36)
+The most recent value.
+
+If `initialData` is passed in, the first value of `data` will be the valuea provided in `initialData` **UNLESS** the underlying observable is ready, in which case it will skip `initialData`.
+
+Defined in: [src/useObservable.ts:55](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L55)
 
 ___
 
@@ -35,7 +39,9 @@ ___
 
 • **error**: *undefined* \| Error
 
-Defined in: [src/useObservable.ts:37](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L37)
+Any error that may have occurred in the underlying observable
+
+Defined in: [src/useObservable.ts:59](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L59)
 
 ___
 
@@ -43,7 +49,9 @@ ___
 
 • **firstValuePromise**: *Promise*<void\>
 
-Defined in: [src/useObservable.ts:38](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L38)
+Promise that resolves after first emit from observable
+
+Defined in: [src/useObservable.ts:63](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L63)
 
 ___
 
@@ -51,7 +59,11 @@ ___
 
 • **hasEmitted**: *boolean*
 
-Defined in: [src/useObservable.ts:34](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L34)
+Indicates whether the hook has emitted a value at some point
+
+If `initialData` is passed in, this will be `true`.
+
+Defined in: [src/useObservable.ts:45](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L45)
 
 ___
 
@@ -59,7 +71,9 @@ ___
 
 • **isComplete**: *boolean*
 
-Defined in: [src/useObservable.ts:35](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L35)
+If this is `true`, the hook will be emitting no further items.
+
+Defined in: [src/useObservable.ts:49](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L49)
 
 ___
 
@@ -67,4 +81,12 @@ ___
 
 • **status**: ``"loading"`` \| ``"error"`` \| ``"success"``
 
-Defined in: [src/useObservable.ts:30](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L30)
+The loading status.
+
+- `loading`: Waiting for the first value from an observable
+- `error`: Something went wrong. Check `ObservableStatus.error` for more details
+- `success`: The hook has emitted at least one value
+
+If `initialData` is passed in, this will skip `loading` and go straight to `success`.
+
+Defined in: [src/useObservable.ts:39](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L39)

--- a/docs/reference/modules/useobservable.md
+++ b/docs/reference/modules/useobservable.md
@@ -58,4 +58,4 @@ ___
 
 **Returns:** [*ObservableStatus*](../interfaces/useobservable.observablestatus.md)<T\>
 
-Defined in: [src/useObservable.ts:41](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L41)
+Defined in: [src/useObservable.ts:66](https://github.com/FirebaseExtended/reactfire/blob/main/src/useObservable.ts#L66)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:firestore": "firebase emulators:exec --only firestore --project rxfire-525a3 \"tsdx test firestore --verbose\"",
     "test:database": "firebase emulators:exec --only database --project rxfire-525a3 \"tsdx test database --verbose\"",
     "test:auth": "firebase emulators:exec --only auth --project rxfire-525a3 \"tsdx test auth --verbose\"",
+    "test:useObservable": "tsdx test useObservable --verbose",
     "lint": "tsdx lint src test",
     "size": "size-limit",
     "analyze": "size-limit --why",

--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -27,15 +27,40 @@ export function preloadObservable<T>(source: Observable<T>, id: string) {
 }
 
 export interface ObservableStatus<T> {
-  status:
-    | 'loading' // waiting for first value from observable
-    | 'error'
-    | 'success'; // has received at least one value
+  /**
+   * The loading status.
+   *
+   * - `loading`: Waiting for the first value from an observable
+   * - `error`: Something went wrong. Check `ObservableStatus.error` for more details
+   * - `success`: The hook has emitted at least one value
+   *
+   * If `initialData` is passed in, this will skip `loading` and go straight to `success`.
+   */
+  status: 'loading' | 'error' | 'success';
+  /**
+   * Indicates whether the hook has emitted a value at some point
+   *
+   * If `initialData` is passed in, this will be `true`.
+   */
   hasEmitted: boolean; // has received at least one value
-  isComplete: boolean; // observable has triggered onComplete event
-  data: T; // latest data from observable
+  /**
+   * If this is `true`, the hook will be emitting no further items.
+   */
+  isComplete: boolean;
+  /**
+   * The most recent value.
+   *
+   * If `initialData` is passed in, the first value of `data` will be the valuea provided in `initialData` **UNLESS** the underlying observable is ready, in which case it will skip `initialData`.
+   */
+  data: T;
+  /**
+   * Any error that may have occurred in the underlying observable
+   */
   error: Error | undefined;
-  firstValuePromise: Promise<void>; // promise that resolves after first emit from observable
+  /**
+   * Promise that resolves after first emit from observable
+   */
+  firstValuePromise: Promise<void>;
 }
 
 export function useObservable<T>(observableId: string, source: Observable<T | any>, config: ReactFireOptions = {}): ObservableStatus<T> {
@@ -79,7 +104,7 @@ export function useObservable<T>(observableId: string, source: Observable<T | an
 
   return {
     status,
-    hasEmitted: observable.hasValue,
+    hasEmitted: observable.hasValue || hasInitialData,
     isComplete: observable.isStopped,
     data: latest,
     error: observable.ourError,

--- a/test/useObservable.test.tsx
+++ b/test/useObservable.test.tsx
@@ -29,6 +29,30 @@ describe('useObservable', () => {
       expect(result.current.isComplete).toEqual(false);
       expect(result.current.status).toEqual('success');
     });
+
+    it('Sets status correctly when passed initialData', () => {
+      const observable$: Subject<any> = new Subject();
+
+      const initialData = 1;
+      const asyncData = 2;
+
+      const { result } = renderHook(() => useObservable('non-suspense test with initialData', observable$, { suspense: false, initialData }));
+
+      expect(result.current.data).toEqual(initialData);
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.firstValuePromise).toBeInstanceOf(Promise);
+      expect(result.current.hasEmitted).toEqual(true); // set `hasEmitted` to true since there is data
+      expect(result.current.isComplete).toEqual(false);
+      expect(result.current.status).toEqual('success'); // skip 'loading'
+
+      actOnHook(() => observable$.next(asyncData));
+
+      expect(result.current.data).toEqual(asyncData);
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.hasEmitted).toEqual(true);
+      expect(result.current.isComplete).toEqual(false);
+      expect(result.current.status).toEqual('success');
+    });
   });
 
   describe('Suspense Mode', () => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Fixes #342 

- Have `useObservable` set `hasEmitted` to `true` when `initialData` is passed in
    - Added a test to verify this behavior
- Update `ObservableStatus` docs to make the values more clear