### PR TITLE
Fix support for rxjs v6.6.3 (#397)

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "rxfire": "5.0.0-rc.1",
-    "rxjs": "^6.6.3 || ^7.0.1"
+    "rxjs": "^7.0.1"
   },
   "resolutions": {
     "tsdx/**/jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "rxfire": "5.0.0-rc.1",
-    "rxjs": "^7.0.1"
+    "rxjs": "^6.6.3 || ^7.0.1"
   },
   "resolutions": {
     "tsdx/**/jest": "^26.6.3",

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -2,7 +2,7 @@ import firebase from 'firebase/app';
 import * as React from 'react';
 import { user } from 'rxfire/auth';
 import { preloadAuth, preloadObservable, ReactFireOptions, useAuth, useObservable, ObservableStatus, ReactFireError } from './';
-import { from, lastValueFrom, of } from 'rxjs';
+import { from, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { useSuspenseEnabledFromConfigAndContext } from './firebaseApp';
 
@@ -11,7 +11,7 @@ export function preloadUser(options: { firebaseApp: firebase.app.App }) {
 
   return preloadAuth({ firebaseApp }).then(auth => {
     const result = preloadObservable(user(auth()), `auth:user:${firebaseApp.name}`);
-    return lastValueFrom(result);
+    return result.toPromise();
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10611,10 +10611,10 @@ rxjs@^6.4.0, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.0.1:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.1.0.tgz#94202d27b19305ef7b1a4f330277b2065df7039e"
-  integrity sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==
+"rxjs@^6.6.3 || ^7.0.1":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.2.0.tgz#5cd12409639e9514a71c9f5f9192b2c4ae94de31"
+  integrity sha512-aX8w9OpKrQmiPKfT1bqETtUr9JygIz6GZ+gql8v7CijClsP0laoFUdKzxFAoWuRdSlOdU2+crss+cMf+cqMTnw==
   dependencies:
     tslib "~2.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10611,7 +10611,7 @@ rxjs@^6.4.0, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-"rxjs@^6.6.3 || ^7.0.1":
+rxjs@^7.0.1:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.1.0.tgz#94202d27b19305ef7b1a4f330277b2065df7039e"
   integrity sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

Closes #397 
### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->
`lastValueFrom` is not available in `rxjs` `v6.6.3`. ~~This pull requests removes the option to use `rxjs` `v6.6.3`.~~ Another option would be to not use `lastValueFrom` as seen here:
https://github.com/FirebaseExtended/reactfire/blob/4d1206d615eeaefc790d99b2c5f07cd44219a455/src/auth.tsx#L5

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
This pull request should not cause any API changes.