### PR TITLE
docs: Mention experimental build of React

### DIFF
--- a/docs/quickstart-concurrent-mode.md
+++ b/docs/quickstart-concurrent-mode.md
@@ -58,12 +58,14 @@ cd myapp
 > Ignore yarn/npm warnings.
 
 ```bash
-yarn add firebase reactfire
+yarn add firebase reactfire react@experimental react-dom@experimental
 
 # or
 
-npm install --save firebase reactfire
+npm install --save firebase reactfire react@experimental react-dom@experimental
 ```
+
+⚠️ **Status: Experimental**. In order to use the feature of concurrent mode, [an experimental build of React is required](https://reactjs.org/docs/concurrent-mode-adoption.html#installation).
 
 ## 4. Register your app with Firebase
 
@@ -111,7 +113,7 @@ npm install --save firebase reactfire
 
    ```jsx
    //...
-   ReactDOM.createRoot(document.getElementById('root')).render(
+   ReactDOM.unstable_createRoot(document.getElementById('root')).render(
      <FirebaseAppProvider firebaseConfig={firebaseConfig} suspense={true}>
        <App />
      </FirebaseAppProvider>


### PR DESCRIPTION
Ref: https://github.com/FirebaseExtended/reactfire/discussions/349

### Description

reactfire originally needed an experimental build of react, but in this [commit](https://github.com/FirebaseExtended/reactfire/commit/5ba5e09be25b1800a4b32e68500f956722bdb068#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-L13), the reference has gone.
Do we still need an experimental build of react to use concurrent mode in reactfire? Or does stable react work fine?
The `createRoot` API does not exist in stable of react 17, so if this pull request is not correct, I think it needs to be mentioned like in the past.

Edit: perhaps, my PR is not correct, however, I want to clarify anyway. 




