### PR TITLE
Align validateClaims to validateCustomClaims

### DIFF
--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -136,9 +136,9 @@ export interface SignInCheckOptionsClaimsValidator extends SignInCheckOptionsBas
 export function useSigninCheck(
   options?: SignInCheckOptionsBasic | SignInCheckOptionsClaimsObject | SignInCheckOptionsClaimsValidator
 ): ObservableStatus<SigninCheckResult> {
-  // If both `requiredClaims` and `validateClaims` are provided, we won't know which one to use
-  if (options?.hasOwnProperty('requiredClaims') && options?.hasOwnProperty('validateClaims')) {
-    throw new Error('Cannot have both "requiredClaims" and "validateClaims". Use one or the other.');
+  // If both `requiredClaims` and `validateCustomClaims` are provided, we won't know which one to use
+  if (options?.hasOwnProperty('requiredClaims') && options?.hasOwnProperty('validateCustomClaims')) {
+    throw new Error('Cannot have both "requiredClaims" and "validateCustomClaims". Use one or the other.');
   }
 
   const auth = useAuth();
@@ -152,14 +152,14 @@ export function useSigninCheck(
     observableId = `${observableId}:requiredClaims:${JSON.stringify((options as SignInCheckOptionsClaimsObject).requiredClaims)}`;
   } else if (options?.hasOwnProperty('validateCustomClaims')) {
     // TODO(jamesdaniels): Check if stringifying this function breaks in IE11
-    observableId = `${observableId}:validateClaims:${JSON.stringify((options as SignInCheckOptionsClaimsValidator).validateCustomClaims)}`;
+    observableId = `${observableId}:validateCustomClaims:${JSON.stringify((options as SignInCheckOptionsClaimsValidator).validateCustomClaims)}`;
   }
 
   const observable = user(auth).pipe(
     switchMap(user => {
       if (!user) {
         return of({ signedIn: false, hasRequiredClaims: false });
-      } else if (options && (options.hasOwnProperty('requiredClaims') || options.hasOwnProperty('validateClaims'))) {
+      } else if (options && (options.hasOwnProperty('requiredClaims') || options.hasOwnProperty('validateCustomClaims'))) {
         return from(user.getIdTokenResult(options?.forceRefresh ?? false)).pipe(
           map(idTokenResult => {
             let validator: ClaimsValidator;

--- a/test/auth.test.tsx
+++ b/test/auth.test.tsx
@@ -197,7 +197,44 @@ describe('Authentication', () => {
       expect(result.current.data.errors as ClaimCheckErrors);
     });
 
-    it('accepts a custom claims validator', async () => {
+    it('accepts a custom claims validator and returns invalid hasRequiredClaims state', async () => {
+      const withClaimsCustomToken = {
+        uid: 'aUserWithCustomClaims',
+        claims: { someClaim: false, someOtherClaim: false }
+      };
+
+      const claimsValidator: ClaimsValidator = userClaims => {
+        const validClaimsSet = ['someClaim', 'someOtherClaim'];
+        let hasAnyClaim = false;
+
+        for (const claim of validClaimsSet) {
+          if (userClaims[claim] === true) {
+            hasAnyClaim = true;
+            break;
+          }
+        }
+
+        return {
+          hasRequiredClaims: hasAnyClaim,
+          errors: hasAnyClaim ? {} : validClaimsSet
+        };
+      };
+
+      const { result, waitFor: waitForHookCondition } = renderHook(() => useSigninCheck({ validateCustomClaims: claimsValidator }), {
+        wrapper: Provider
+      });
+
+      await hooksAct(async () => {
+        await app.auth().signInWithCustomToken(JSON.stringify(withClaimsCustomToken));
+      });
+
+      await waitForHookCondition(() => result.current.status === 'success');
+
+      expect(result.current.data.signedIn).toEqual(true);
+      expect(result.current.data.hasRequiredClaims).toEqual(false);
+    });
+
+    it('accepts a custom claims validator and returns valid hasRequiredClaims state', async () => {
       const withClaimsCustomToken = {
         uid: 'aUserWithCustomClaims',
         claims: { someClaim: true, someOtherClaim: false }


### PR DESCRIPTION
When I passed `validateCustomClaims`, the callback was not called, so I looked at the code and found that [the key name was different](https://github.com/FirebaseExtended/reactfire/blob/804b3e56ccc3d1595431437627f9baeb362c4d37/src/auth.tsx#L162) from what I was expecting.