### PR TITLE
Cleanup: use RxFire's fromTask

### DIFF
--- a/docs/reference/modules/storage.md
+++ b/docs/reference/modules/storage.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[src/storage.tsx:100](https://github.com/FirebaseExtended/reactfire/blob/main/src/storage.tsx#L100)
+[src/storage.tsx:78](https://github.com/FirebaseExtended/reactfire/blob/main/src/storage.tsx#L78)
 
 ___
 
@@ -57,7 +57,7 @@ Subscribe to a storage ref's download URL
 
 #### Defined in
 
-[src/storage.tsx:51](https://github.com/FirebaseExtended/reactfire/blob/main/src/storage.tsx#L51)
+[src/storage.tsx:29](https://github.com/FirebaseExtended/reactfire/blob/main/src/storage.tsx#L29)
 
 ___
 
@@ -87,4 +87,4 @@ Subscribe to the progress of a storage task
 
 #### Defined in
 
-[src/storage.tsx:38](https://github.com/FirebaseExtended/reactfire/blob/main/src/storage.tsx#L38)
+[src/storage.tsx:16](https://github.com/FirebaseExtended/reactfire/blob/main/src/storage.tsx#L16)

--- a/src/storage.tsx
+++ b/src/storage.tsx
@@ -1,32 +1,10 @@
 import * as React from 'react';
-import { getDownloadURL } from 'rxfire/storage';
-import { Observable } from 'rxjs';
+import { getDownloadURL, fromTask } from 'rxfire/storage';
 import { ReactFireOptions, useObservable, ObservableStatus, useStorage } from './';
 import { useSuspenseEnabledFromConfigAndContext } from './firebaseApp';
 import { ref } from 'firebase/storage';
 
 import type { UploadTask, UploadTaskSnapshot, StorageReference, FirebaseStorage } from 'firebase/storage';
-
-/**
- * modified version of rxFire's _fromTask
- *
- * @param task
- */
-function _fromTask(task: UploadTask) {
-  return new Observable<UploadTaskSnapshot>((subscriber) => {
-    const progress = (snap: UploadTaskSnapshot) => {
-      return subscriber.next(snap);
-    };
-    const error = (e: any) => subscriber.error(e);
-    const complete = () => {
-      return subscriber.complete();
-    };
-    task.on('state_changed', progress, error, complete);
-
-    // I REMOVED THE UNSUBSCRIBE RETURN BECAUSE IT CANCELS THE UPLOAD
-    // https://github.com/firebase/firebase-js-sdk/issues/1659
-  });
-}
 
 /**
  * Subscribe to the progress of a storage task
@@ -37,7 +15,7 @@ function _fromTask(task: UploadTask) {
  */
 export function useStorageTask<T = unknown>(task: UploadTask, ref: StorageReference, options?: ReactFireOptions<T>): ObservableStatus<UploadTaskSnapshot | T> {
   const observableId = `storage:task:${ref.toString()}`;
-  const observable$ = _fromTask(task);
+  const observable$ = fromTask(task);
 
   return useObservable(observableId, observable$, options);
 }

--- a/test/storage.test.tsx
+++ b/test/storage.test.tsx
@@ -26,7 +26,7 @@ describe('Storage', () => {
 
       const uploadTask = uploadBytesResumable(testFileRef, someBytes);
 
-      const { result } = renderHook(() => useStorageTask<UploadTaskSnapshot>(uploadTask, testFileRef), { wrapper: Provider });
+      const { result, waitFor } = renderHook(() => useStorageTask<UploadTaskSnapshot>(uploadTask, testFileRef), { wrapper: Provider });
 
       const uploadTaskSnapshots: Array<UploadTaskSnapshot> = [];
       let hasUploadTaskCompleted = false;
@@ -44,8 +44,8 @@ describe('Storage', () => {
         }
       );
 
-      await actOnHooks(async () => {
-        await uploadTask.then();
+      await waitFor(() => {
+        return hasUploadTaskCompleted && result.current.isComplete;
       });
 
       expect(result.error).toEqual(uploadTaskError);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Due to https://github.com/firebase/firebase-js-sdk/issues/1659, ReactFire originally implemented its own `fromTask` observable instead of using RxFire's. This issue was fixed in https://github.com/FirebaseExtended/rxfire/pull/8, so now we should use RxFire's `fromTask` instead.