### PR TITLE
add useCallableFunctionResponse

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -11,6 +11,7 @@ ReactFire reference docs
 - [database](modules/database.md)
 - [firebaseApp](modules/firebaseApp.md)
 - [firestore](modules/firestore.md)
+- [functions](modules/functions.md)
 - [index](modules/index.md)
 - [performance](modules/performance.md)
 - [remote-config](modules/remote_config.md)

--- a/docs/reference/modules/functions.md
+++ b/docs/reference/modules/functions.md
@@ -1,0 +1,39 @@
+[ReactFire reference docs](../README.md) / functions
+
+# Module: functions
+
+## Table of contents
+
+### Functions
+
+- [useCallableFunctionResponse](functions.md#usecallablefunctionresponse)
+
+## Functions
+
+### useCallableFunctionResponse
+
+▸ **useCallableFunctionResponse**<`RequestData`, `ResponseData`\>(`functionName`, `options?`): [`ObservableStatus`](../interfaces/useObservable.ObservableStatus.md)<`ResponseData`\>
+
+Calls a callable function.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `RequestData` |
+| `ResponseData` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `functionName` | `string` | The name of the function to call |
+| `options?` | [`ReactFireOptions`](../interfaces/index.ReactFireOptions.md)<`ResponseData`\> & { `data?`: `RequestData` ; `httpsCallableOptions?`: `HttpsCallableOptions`  } |  |
+
+#### Returns
+
+[`ObservableStatus`](../interfaces/useObservable.ObservableStatus.md)<`ResponseData`\>
+
+#### Defined in
+
+src/functions.tsx:13

--- a/docs/reference/modules/functions.md
+++ b/docs/reference/modules/functions.md
@@ -36,4 +36,4 @@ Calls a callable function.
 
 #### Defined in
 
-src/functions.tsx:13
+[src/functions.tsx:13](https://github.com/FirebaseExtended/reactfire/blob/main/src/functions.tsx#L13)

--- a/docs/reference/modules/index.md
+++ b/docs/reference/modules/index.md
@@ -36,6 +36,7 @@
 - [useAnalytics](index.md#useanalytics)
 - [useAppCheck](index.md#useappcheck)
 - [useAuth](index.md#useauth)
+- [useCallableFunctionResponse](index.md#usecallablefunctionresponse)
 - [useDatabase](index.md#usedatabase)
 - [useDatabaseList](index.md#usedatabaselist)
 - [useDatabaseListData](index.md#usedatabaselistdata)
@@ -274,6 +275,12 @@ ___
 ### useAuth
 
 Re-exports: [useAuth](sdk.md#useauth)
+
+___
+
+### useCallableFunctionResponse
+
+Re-exports: [useCallableFunctionResponse](functions.md#usecallablefunctionresponse)
 
 ___
 

--- a/docs/use.md
+++ b/docs/use.md
@@ -14,7 +14,8 @@
   * [Show a single document](#show-a-single-document)
   * [Show a list of data (collection)](#show-a-list-of-data-collection)
 - [Cloud Functions](#cloud-functions)
-  * [Call a function](#call-a-function)
+  * [Call a function based on user interaction](#call-a-function-based-on-user-interaction)
+  * [Call a function on render](#call-a-function-on-render)
 - [Realtime Database](#realtime-database)
   * [Show an object](#show-an-object)
   * [Show a list of data](#show-a-list-of-data)
@@ -304,7 +305,7 @@ function FavoriteAnimals() {
 
 The following samples assume that `FirebaseAppProvider` and `FunctionsProvider` components exist higher up the component tree.
 
-### Call a function
+### Call a function based on user interaction
 
 ```jsx
 function Calculator() {
@@ -324,6 +325,18 @@ function Calculator() {
   } else {
     return <pre>{calculationResult}</pre>;
   }
+}
+```
+
+### Call a function on render
+
+If you want to call a function when a component renders, instead of in response to user interaction, you can use the `useCallableFunctionResponse` hook.
+
+```jsx
+function LikeCount({ videoId }) {
+  const { status, data: likeCount } = useCallableFunctionResponse('capitalizeText', { data: { videoId: videoId } });
+
+  return <span>This video has {status === 'loading' ? '...' : likeCount} views</span>;
 }
 ```
 

--- a/docs/use.md
+++ b/docs/use.md
@@ -336,7 +336,7 @@ If you want to call a function when a component renders, instead of in response 
 function LikeCount({ videoId }) {
   const { status, data: likeCount } = useCallableFunctionResponse('countVideoLikes', { data: { videoId: videoId } });
 
-  return <span>This video has {status === 'loading' ? '...' : likeCount} views</span>;
+  return <span>This video has {status === 'loading' ? '...' : likeCount} likes</span>;
 }
 ```
 

--- a/docs/use.md
+++ b/docs/use.md
@@ -334,7 +334,7 @@ If you want to call a function when a component renders, instead of in response 
 
 ```jsx
 function LikeCount({ videoId }) {
-  const { status, data: likeCount } = useCallableFunctionResponse('capitalizeText', { data: { videoId: videoId } });
+  const { status, data: likeCount } = useCallableFunctionResponse('countVideoLikes', { data: { videoId: videoId } });
 
   return <span>This video has {status === 'loading' ? '...' : likeCount} views</span>;
 }

--- a/example/withoutSuspense/Functions.tsx
+++ b/example/withoutSuspense/Functions.tsx
@@ -1,7 +1,7 @@
 import 'firebase/storage';
 import * as React from 'react';
 import { useState } from 'react';
-import { useFirebaseApp, FunctionsProvider, useFunctions } from 'reactfire';
+import { useFirebaseApp, FunctionsProvider, useFunctions, useCallableFunctionResponse } from 'reactfire';
 import { CardSection } from '../display/Card';
 import { LoadingSpinner } from '../display/LoadingSpinner';
 import { WideButton } from '../display/Button';
@@ -13,11 +13,12 @@ function UpperCaser() {
   const [uppercasedText, setText] = useState<string>('');
   const [isUppercasing, setIsUppercasing] = useState<boolean>(false);
 
+  const greetings = ['Hello World', 'yo', `what's up?`];
+  const textToUppercase = greetings[Math.floor(Math.random() * greetings.length)];
+
   async function handleButtonClick() {
     setIsUppercasing(true);
 
-    const greetings = ['Hello World', 'yo', `what's up?`];
-    const textToUppercase = greetings[Math.floor(Math.random() * greetings.length)];
     const { data: capitalizedText } = await capitalizeTextRemoteFunction({ text: textToUppercase });
     setText(capitalizedText);
 
@@ -27,9 +28,21 @@ function UpperCaser() {
   return (
     <>
       <WideButton label="Uppercase some text" onClick={handleButtonClick} />
-      {isUppercasing ? <LoadingSpinner /> : <span>{uppercasedText}</span>}
+      {isUppercasing ? <LoadingSpinner /> : <span>{uppercasedText || `click the button to capitalize "${textToUppercase}"`}</span>}
     </>
   );
+}
+
+function UpperCaserOnRender() {
+  const greetings = ['Hello World', 'yo', `what's up?`];
+  const textToUppercase = greetings[Math.floor(Math.random() * greetings.length)];
+  const { status, data: uppercasedText } = useCallableFunctionResponse<{ text: string }, string>('capitalizeText', { data: { text: textToUppercase } });
+
+  if (status === 'loading') {
+    return <LoadingSpinner />;
+  }
+
+  return <span>{uppercasedText}</span>;
 }
 
 export function Functions() {
@@ -39,6 +52,9 @@ export function Functions() {
     <FunctionsProvider sdk={getFunctions(app)}>
       <CardSection title="Call a cloud function">
         <UpperCaser />
+      </CardSection>
+      <CardSection title="Call a function on render">
+        <UpperCaserOnRender />
       </CardSection>
     </FunctionsProvider>
   );

--- a/src/functions.tsx
+++ b/src/functions.tsx
@@ -1,0 +1,28 @@
+import { httpsCallable as rxHttpsCallable } from 'rxfire/functions';
+import { ReactFireOptions, useObservable, ObservableStatus } from './';
+import { useFunctions } from '.';
+
+import type { HttpsCallableOptions } from 'firebase/functions';
+
+/**
+ * Calls a callable function.
+ *
+ * @param functionName - The name of the function to call
+ * @param options
+ */
+export function useCallableFunctionResponse<RequestData, ResponseData>(
+  functionName: string,
+  options?: ReactFireOptions<ResponseData> & {
+    httpsCallableOptions?: HttpsCallableOptions;
+    data?: RequestData;
+  }
+): ObservableStatus<ResponseData> {
+  const functions = useFunctions();
+  const observableId = `functions:callableResponse:${functionName}:${JSON.stringify(options?.data)}:${JSON.stringify(options?.httpsCallableOptions)}`;
+  const obsFactory = rxHttpsCallable<RequestData, ResponseData>(functions, functionName, options?.httpsCallableOptions);
+
+  //@ts-expect-error because RxFire doesn't make data optional. Remove when https://github.com/FirebaseExtended/rxfire/pull/34 is released.
+  const observable$ = obsFactory(options?.data);
+
+  return useObservable(observableId, observable$, options);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export * from './auth';
 export * from './database';
 export * from './firebaseApp';
 export * from './firestore';
+export * from './functions';
 export * from './performance';
 export * from './remote-config';
 export * from './storage';

--- a/test/functions.test.tsx
+++ b/test/functions.test.tsx
@@ -1,9 +1,10 @@
 import { initializeApp } from 'firebase/app';
 import { getFunctions, connectFunctionsEmulator, httpsCallable } from 'firebase/functions';
 import { FunctionComponent } from 'react';
-import { FirebaseAppProvider, FunctionsProvider, useFunctions } from '..';
+import { FirebaseAppProvider, FunctionsProvider, useFunctions, useCallableFunctionResponse } from '..';
 import { baseConfig } from './appConfig';
 import { renderHook } from '@testing-library/react-hooks';
+import { randomString } from './test-utils';
 import * as React from 'react';
 
 describe('Functions', () => {
@@ -25,12 +26,25 @@ describe('Functions', () => {
       expect(functionsInstance).toBeDefined();
 
       // `capitalizeText` function is in `functions/index.js`
-      const capitalizeTextRemoteFunction = httpsCallable(functionsInstance, 'capitalizeText');
+      const capitalizeTextRemoteFunction = httpsCallable<{ text: string }, string>(functionsInstance, 'capitalizeText');
       const testText = 'Hello World';
 
       const { data: capitalizedText } = await capitalizeTextRemoteFunction({ text: testText });
 
       expect(capitalizedText).toEqual(testText.toUpperCase());
+    });
+  });
+
+  describe('useCallableFunctionResponse', () => {
+    it('calls a function on render', async () => {
+      const testText = randomString();
+      const { result, waitFor } = renderHook(() => useCallableFunctionResponse<{ text: string }, string>('capitalizeText', { data: { text: testText } }), {
+        wrapper: Provider,
+      });
+
+      await waitFor(() => result.current.status === 'success');
+
+      expect(result.current.data).toEqual(testText.toUpperCase());
     });
   });
 });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Add the `useCallableFunctionResponse` hook, which makes it easy to call a callable function on render.

fixes #447 

### Code sample

```jsx
import { useCallableFunctionResponse } from "reactfire";

function LikeCount({ videoId }) {
  const { status, data: likeCount } = useCallableFunctionResponse(
    "countVideoLikes",
    { data: { videoId: videoId } }
  );

  return (
    <span>This video has {status === "loading" ? "..." : likeCount} likes</span>
  );
}
```

---

Note: We also discuss `useGetCallableFunction` in #447, but I've left that out of this PR. After some more thought, I don't think it is worth the maintenance burden, since it is easy enough to use the Firebase JS SDK directly for that use case:

```js
import { useFunctions } from "reactfire";
import { httpsCallable } from "firebase/functions";

function MyComponent() {
  const remoteCalculator = httpsCallable(useFunctions(), "calculate");

  //...
}
```