### PR TITLE
Fix reconciler : Expose the contexts

### DIFF
--- a/src/sdk.tsx
+++ b/src/sdk.tsx
@@ -15,15 +15,15 @@ import { ObservableStatus, useObservable } from './useObservable';
 import { from } from 'rxjs';
 import { ReactFireOptions } from '.';
 
-const AppCheckSdkContext = React.createContext<AppCheck | undefined>(undefined);
-const AuthSdkContext = React.createContext<Auth | undefined>(undefined);
-const AnalyticsSdkContext = React.createContext<Analytics | undefined>(undefined);
-const DatabaseSdkContext = React.createContext<Database | undefined>(undefined);
-const FirestoreSdkContext = React.createContext<Firestore | undefined>(undefined);
-const FunctionsSdkContext = React.createContext<Functions | undefined>(undefined);
-const StorageSdkContext = React.createContext<FirebaseStorage | undefined>(undefined);
-const PerformanceSdkContext = React.createContext<FirebasePerformance | undefined>(undefined);
-const RemoteConfigSdkContext = React.createContext<RemoteConfig | undefined>(undefined);
+export const AppCheckSdkContext = React.createContext<AppCheck | undefined>(undefined);
+export const AuthSdkContext = React.createContext<Auth | undefined>(undefined);
+export const AnalyticsSdkContext = React.createContext<Analytics | undefined>(undefined);
+export const DatabaseSdkContext = React.createContext<Database | undefined>(undefined);
+export const FirestoreSdkContext = React.createContext<Firestore | undefined>(undefined);
+export const FunctionsSdkContext = React.createContext<Functions | undefined>(undefined);
+export const StorageSdkContext = React.createContext<FirebaseStorage | undefined>(undefined);
+export const PerformanceSdkContext = React.createContext<FirebasePerformance | undefined>(undefined);
+export const RemoteConfigSdkContext = React.createContext<RemoteConfig | undefined>(undefined);
 
 type FirebaseSdks = Analytics | AppCheck | Auth | Database | Firestore | FirebasePerformance | FirebaseStorage | Functions | RemoteConfig;
 


### PR DESCRIPTION
Hello! 

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

To consume the contexts with [react reconciler](https://www.npmjs.com/package/react-reconciler) you need to forward the contexts using a "bridge".
See https://github.com/facebook/react/issues/17275
Exposing each context is then necessary if we don't want to wrap all our components twice in that case.
