### PR TITLE
updating docs from 'useSignInCheck' to 'useSigninCheck'

### DIFF
--- a/docs/reference/modules/auth.md
+++ b/docs/reference/modules/auth.md
@@ -43,7 +43,7 @@
 
 ▸ **AuthCheck**(`__namedParameters`): `JSX.Element`
 
-**`deprecated`** Use `useSignInCheck` instead
+**`deprecated`** Use `useSigninCheck` instead
 
 Conditionally render children based on signed-in status and [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims).
 
@@ -69,7 +69,7 @@ ___
 
 ▸ **ClaimsCheck**(`__namedParameters`): `Element`
 
-**`deprecated`** Use `useSignInCheck` instead
+**`deprecated`** Use `useSigninCheck` instead
 
 Conditionally render children based on [custom claims](https://firebase.google.com/docs/auth/admin/custom-claims).
 
@@ -156,15 +156,15 @@ Optionally check [custom claims](https://firebase.google.com/docs/auth/admin/cus
 
 ```ts
 // pass in an object describing the custom claims a user must have
-const {status, data: signInCheckResult} = useSignInCheck({requiredClaims: {admin: true}});
+const {status, data: signInCheckResult} = useSigninCheck({requiredClaims: {admin: true}});
 
 // pass in a custom claims validator function
-const {status, data: signInCheckResult} = useSignInCheck({validateCustomClaims: (userClaims) => {
+const {status, data: signInCheckResult} = useSigninCheck({validateCustomClaims: (userClaims) => {
   // custom validation logic...
 }});
 
 // You can optionally force-refresh the token
-const {status, data: signInCheckResult} = useSignInCheck({forceRefresh: true, requiredClaims: {admin: true}});
+const {status, data: signInCheckResult} = useSigninCheck({forceRefresh: true, requiredClaims: {admin: true}});
 ```
 
 #### Parameters

--- a/docs/use.md
+++ b/docs/use.md
@@ -206,12 +206,12 @@ To check [custom claims](https://firebase.google.com/docs/auth/admin/custom-clai
 
 ```jsx
 // pass in an object describing the custom claims a user must have
-const { status, data: signInCheckResult } = useSignInCheck({ requiredClaims: { superUser: true } });
+const { status, data: signInCheckResult } = useSigninCheck({ requiredClaims: { superUser: true } });
 
 // OR
 
 // pass in a custom claims validator function
-const { status, data: signInCheckResult } = useSignInCheck({
+const { status, data: signInCheckResult } = useSigninCheck({
   validateCustomClaims: (userClaims) => {
     // custom validation logic...
     return {


### PR DESCRIPTION
Ran into import errors when following the docs because of this subtle lowercase `i`.

I think overall it would be worth having this camel case exception be consistent with `signInCheckResult`, but not worth introducing a breaking change in my opinion, so just looking to update the docs and references in this repo.
