### PR TITLE
Fix for evaluating initialData of observable

### DIFF
--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -100,7 +100,9 @@ export function useObservable<T = unknown>(observableId: string, source: Observa
   const observable = preloadObservable(source, observableId);
 
   // Suspend if suspense is enabled and no initial data exists
-  const hasInitialData = config.hasOwnProperty('initialData') || config.hasOwnProperty('startWithValue');
+  // Changed from using Object.hasOwnProperty() to evaluating
+  // the falsy of the properties as a boolean.
+  const hasInitialData = !!(config.initialData || config.startWithValue);
   const hasData = observable.hasValue || hasInitialData;
   const suspenseEnabled = useSuspenseEnabledFromConfigAndContext(config.suspense);
   if (suspenseEnabled === true && !hasData) {


### PR DESCRIPTION
Changing the useObservable method to
evaluate initialData as falsy rather than
using hasOwnProperty which accidentally
returns "success" early from an observable.

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

CLA signed for this account.

Relevant issue: #495 

Tests for useObservable still passing. I did not get the emulators set up properly for some of the additional tests on my own machine. 

Currently your docs state that useUser should be returning "loading" until it emits it's first value, however you are accidentally interpreting `initialData: undefined | null` as equal to `true` thus returning the wrong status on first render. This fixes that. I simply changed one line to make it so that it evaluates the falsy value of the initialData coming in rather than the existence of the property, so that it does not have false positives like this in the future. I am not certain if this could cause other unintended consequences, I would appreciate if a maintainer has time to take a look.

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
