### PR TITLE
pass options from useSigninCheck to useObservable

### DIFF
--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -180,7 +180,7 @@ export function useSigninCheck(
     })
   );
 
-  return useObservable(observableId, observable);
+  return useObservable(observableId, observable, options);
 }
 
 function getClaimsObjectValidator(requiredClaims: Claims): ClaimsValidator {


### PR DESCRIPTION
### Description

While trying to debug while useSigninCheck suspends indefinitely on latest version and master, I tried to disable suspense but this was not working. Having cloned the repo locally and debugged I noticed that the options used in useSigninCheck was never passed to useObservable which takes the options object.