### PR TITLE
Remove `useUser`'s `initialData` override

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -131,7 +131,7 @@ ___
 
 #### Defined in
 
-[src/auth.tsx:66](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L66)
+[src/auth.tsx:59](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L59)
 
 ## Variables
 
@@ -299,7 +299,7 @@ Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More 
 
 #### Defined in
 
-[src/auth.tsx:247](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L247)
+[src/auth.tsx:240](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L240)
 
 ___
 
@@ -347,7 +347,7 @@ Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More 
 
 #### Defined in
 
-[src/auth.tsx:210](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L210)
+[src/auth.tsx:203](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L203)
 
 ___
 
@@ -1097,7 +1097,7 @@ ___
 
 #### Defined in
 
-[src/auth.tsx:38](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L38)
+[src/auth.tsx:31](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L31)
 
 ___
 
@@ -1517,7 +1517,7 @@ const {status, data: signInCheckResult} = useSigninCheck({forceRefresh: true, re
 
 #### Defined in
 
-[src/auth.tsx:131](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L131)
+[src/auth.tsx:124](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L124)
 
 ___
 

--- a/docs/reference/interfaces/AuthCheckProps.md
+++ b/docs/reference/interfaces/AuthCheckProps.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[src/auth.tsx:51](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L51)
+[src/auth.tsx:44](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L44)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[src/auth.tsx:50](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L50)
+[src/auth.tsx:43](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L43)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[src/auth.tsx:52](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L52)
+[src/auth.tsx:45](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L45)

--- a/docs/reference/interfaces/ClaimsCheckProps.md
+++ b/docs/reference/interfaces/ClaimsCheckProps.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[src/auth.tsx:58](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L58)
+[src/auth.tsx:51](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L51)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[src/auth.tsx:57](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L57)
+[src/auth.tsx:50](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L50)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[src/auth.tsx:59](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L59)
+[src/auth.tsx:52](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L52)
 
 ___
 
@@ -53,4 +53,4 @@ ___
 
 #### Defined in
 
-[src/auth.tsx:56](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L56)
+[src/auth.tsx:49](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L49)

--- a/docs/reference/interfaces/ClaimsValidator.md
+++ b/docs/reference/interfaces/ClaimsValidator.md
@@ -25,4 +25,4 @@
 
 #### Defined in
 
-[src/auth.tsx:89](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L89)
+[src/auth.tsx:82](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L82)

--- a/docs/reference/interfaces/SignInCheckOptionsBasic.md
+++ b/docs/reference/interfaces/SignInCheckOptionsBasic.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[src/auth.tsx:81](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L81)
+[src/auth.tsx:74](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L74)
 
 ___
 

--- a/docs/reference/interfaces/SignInCheckOptionsClaimsObject.md
+++ b/docs/reference/interfaces/SignInCheckOptionsClaimsObject.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[src/auth.tsx:81](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L81)
+[src/auth.tsx:74](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L74)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[src/auth.tsx:85](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L85)
+[src/auth.tsx:78](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L78)
 
 ___
 

--- a/docs/reference/interfaces/SignInCheckOptionsClaimsValidator.md
+++ b/docs/reference/interfaces/SignInCheckOptionsClaimsValidator.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[src/auth.tsx:81](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L81)
+[src/auth.tsx:74](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L74)
 
 ___
 
@@ -101,4 +101,4 @@ ___
 
 #### Defined in
 
-[src/auth.tsx:96](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L96)
+[src/auth.tsx:89](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L89)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reactfire",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reactfire",
-      "version": "4.2.2",
+      "version": "4.2.3",
       "license": "MIT",
       "dependencies": {
         "rxfire": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.2.2",
+  "version": "4.2.3",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.umd.cjs",

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -24,15 +24,8 @@ export function useUser<T = unknown>(options?: ReactFireOptions<T>): ObservableS
 
   const observableId = `auth:user:${auth.name}`;
   const observable$ = user(auth);
-  const _options: ReactFireOptions<T> = { ...options } ?? {};
 
-  // only set/override initialData if auth has finished loading
-  if (auth.currentUser !== undefined) {
-    _options.initialData = auth.currentUser;
-    _options.startWithValue = auth.currentUser;
-  }
-
-  return useObservable(observableId, observable$, _options);
+  return useObservable(observableId, observable$, options);
 }
 
 export function useIdTokenResult(user: User, forceRefresh: boolean = false, options?: ReactFireOptions<IdTokenResult>): ObservableStatus<IdTokenResult> {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

`useUser` currently overrides `initialData` if `auth.currentUser` is not undefined:

https://github.com/FirebaseExtended/reactfire/blob/414201e88bd6f6701998993f6203e4d49773147b/src/auth.tsx#L29-L33

The idea was that we might be able to get `useUser` to load with the correct auth state faster than if we had waited for the underlying `useIdTokenResult` to finish. This was based on the assumption that `auth.currentUser` is `undefined` while the Auth SDK is booting up, `null` _only_ when the Auth SDK is booted up and a user isn't signed in, and truthy otherwise.

However, this is [undocumented behavior](https://firebase.google.com/docs/reference/js/auth.auth.md#authcurrentuser), so we shouldn't rely on it.