### PR TITLE
chore: migrate moduleResolution from node to bundler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,7 @@
     // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "moduleResolution": "bundler",
     // transpile JSX to React.createElement
     "jsx": "react",
     // interop between ESM and CJS modules. Recommended by TS


### PR DESCRIPTION
Fixes #723

Switches `moduleResolution` from the deprecated `"node"` strategy to `"bundler"` in `tsconfig.json` and removes the `ignoreDeprecations` suppression.

The original blocker was rxfire's subpath imports (`rxfire/firestore`, `rxfire/auth` etc.) not resolving correctly under `"bundler"`. rxfire 6.1.0 now ships a full `exports` map with `types` fields for all subpaths, so the blocker is resolved. Type checking passes cleanly with no errors.