### PR TITLE
fix: use globalThis.performance in SuspenseWithPerf to avoid SSR crash

### DIFF
--- a/src/performance.tsx
+++ b/src/performance.tsx
@@ -9,17 +9,18 @@ export interface SuspensePerfProps {
 export function SuspenseWithPerf({ children, traceId, fallback }: SuspensePerfProps): JSX.Element {
   // TODO: Should this import firebase/performance?
 
-  const entries = performance?.getEntriesByName?.(traceId, 'measure') || [];
+  const perf = typeof globalThis !== 'undefined' ? globalThis.performance : undefined;
+  const entries = perf?.getEntriesByName?.(traceId, 'measure') || [];
   const startMarkName = `_${traceId}Start[${entries.length}]`;
   const endMarkName = `_${traceId}End[${entries.length}]`;
 
   const Fallback = () => {
     React.useLayoutEffect(() => {
-      performance?.mark?.(startMarkName);
+      perf?.mark?.(startMarkName);
 
       return () => {
-        performance?.mark?.(endMarkName);
-        performance?.measure?.(traceId, startMarkName, endMarkName);
+        perf?.mark?.(endMarkName);
+        perf?.measure?.(traceId, startMarkName, endMarkName);
       };
     }, []);
 

--- a/src/performance.tsx
+++ b/src/performance.tsx
@@ -15,7 +15,7 @@ export function SuspenseWithPerf({ children, traceId, fallback }: SuspensePerfPr
   const endMarkName = `_${traceId}End[${entries.length}]`;
 
   const Fallback = () => {
-    React.useLayoutEffect(() => {
+    React.useEffect(() => {
       perf?.mark?.(startMarkName);
 
       return () => {


### PR DESCRIPTION
Fixes #328

`SuspenseWithPerf` was accessing the `performance` global directly, which throws a `ReferenceError` in SSR environments (e.g. Next.js) where `performance` is not defined as a global variable.

Replaces direct `performance` access with `globalThis.performance`, which is always safe to access. If `performance` is not available in the environment, it returns `undefined` and the optional chaining handles it gracefully — no crash.

A follow-up enhancement (tracked in #328) could have `SuspenseWithPerf` self-initialize Firebase Performance via `useInitPerformance` for richer RUM integration.