### PR TITLE
fix: replace JSX.Element with React types for React 19 compatibility

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,6 +79,27 @@ jobs:
           ./reactfire-${{ github.run_id }}/unpack.sh
       - name: Run tests
         run: npm run test
+  type-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        react: ["18", "19"]
+      fail-fast: false
+    name: Type check (React ${{ matrix.react }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - name: Install deps
+        run: npm ci
+      - name: Install React ${{ matrix.react }} types
+        run: npm install --no-save react@${{ matrix.react }} react-dom@${{ matrix.react }} @types/react@${{ matrix.react }} @types/react-dom@${{ matrix.react }}
+      - name: Type check
+        run: npx tsc --noEmit
   publish:
     runs-on: ubuntu-latest
     name: Publish (NPM)

--- a/docs/reference/functions/AuthCheck.md
+++ b/docs/reference/functions/AuthCheck.md
@@ -6,7 +6,7 @@
 
 # ~~Function: AuthCheck()~~
 
-> **AuthCheck**(`__namedParameters`): `Element`
+> **AuthCheck**(`__namedParameters`): `ReactElement`
 
 Defined in: [src/auth.tsx:247](https://github.com/FirebaseExtended/reactfire/blob/main/src/auth.tsx#L247)
 
@@ -18,7 +18,7 @@ Defined in: [src/auth.tsx:247](https://github.com/FirebaseExtended/reactfire/blo
 
 ## Returns
 
-`Element`
+`ReactElement`
 
 ## Deprecated
 

--- a/docs/reference/functions/SuspenseWithPerf.md
+++ b/docs/reference/functions/SuspenseWithPerf.md
@@ -6,7 +6,7 @@
 
 # Function: SuspenseWithPerf()
 
-> **SuspenseWithPerf**(`__namedParameters`): `Element`
+> **SuspenseWithPerf**(`__namedParameters`): `ReactElement`
 
 Defined in: [src/performance.tsx:9](https://github.com/FirebaseExtended/reactfire/blob/main/src/performance.tsx#L9)
 
@@ -18,4 +18,4 @@ Defined in: [src/performance.tsx:9](https://github.com/FirebaseExtended/reactfir
 
 ## Returns
 
-`Element`
+`ReactElement`

--- a/docs/reference/interfaces/ObservableStatusSuccess.md
+++ b/docs/reference/interfaces/ObservableStatusSuccess.md
@@ -46,7 +46,7 @@ Any error that may have occurred in the underlying observable
 
 #### Inherited from
 
-[`ObservableStatusLoading`](ObservableStatusLoading.md).[`error`](ObservableStatusLoading.md#error)
+`ObservableStatusBase.error`
 
 ***
 
@@ -60,7 +60,7 @@ Promise that resolves after first emit from observable
 
 #### Inherited from
 
-[`ObservableStatusError`](ObservableStatusError.md).[`firstValuePromise`](ObservableStatusError.md#firstvaluepromise)
+`ObservableStatusBase.firstValuePromise`
 
 ***
 
@@ -76,7 +76,7 @@ If `initialData` is passed in, this will be `true`.
 
 #### Inherited from
 
-[`ObservableStatusError`](ObservableStatusError.md).[`hasEmitted`](ObservableStatusError.md#hasemitted)
+`ObservableStatusBase.hasEmitted`
 
 ***
 
@@ -90,7 +90,7 @@ If this is `true`, the hook will be emitting no further items.
 
 #### Inherited from
 
-[`ObservableStatusLoading`](ObservableStatusLoading.md).[`isComplete`](ObservableStatusLoading.md#iscomplete)
+`ObservableStatusBase.isComplete`
 
 ***
 

--- a/docs/reference/interfaces/ObservableStatusSuccess.md
+++ b/docs/reference/interfaces/ObservableStatusSuccess.md
@@ -46,7 +46,7 @@ Any error that may have occurred in the underlying observable
 
 #### Inherited from
 
-`ObservableStatusBase.error`
+[`ObservableStatusLoading`](ObservableStatusLoading.md).[`error`](ObservableStatusLoading.md#error)
 
 ***
 
@@ -60,7 +60,7 @@ Promise that resolves after first emit from observable
 
 #### Inherited from
 
-`ObservableStatusBase.firstValuePromise`
+[`ObservableStatusError`](ObservableStatusError.md).[`firstValuePromise`](ObservableStatusError.md#firstvaluepromise)
 
 ***
 
@@ -76,7 +76,7 @@ If `initialData` is passed in, this will be `true`.
 
 #### Inherited from
 
-`ObservableStatusBase.hasEmitted`
+[`ObservableStatusError`](ObservableStatusError.md).[`hasEmitted`](ObservableStatusError.md#hasemitted)
 
 ***
 
@@ -90,7 +90,7 @@ If this is `true`, the hook will be emitting no further items.
 
 #### Inherited from
 
-`ObservableStatusBase.isComplete`
+[`ObservableStatusLoading`](ObservableStatusLoading.md).[`isComplete`](ObservableStatusLoading.md#iscomplete)
 
 ***
 

--- a/docs/reference/type-aliases/StorageImageProps.md
+++ b/docs/reference/type-aliases/StorageImageProps.md
@@ -14,7 +14,7 @@ Defined in: [src/storage.tsx:36](https://github.com/FirebaseExtended/reactfire/b
 
 ### placeHolder?
 
-> `optional` **placeHolder?**: `JSX.Element`
+> `optional` **placeHolder?**: `React.ReactNode`
 
 Defined in: [src/storage.tsx:40](https://github.com/FirebaseExtended/reactfire/blob/main/src/storage.tsx#L40)
 

--- a/docs/reference/variables/AnalyticsProvider.md
+++ b/docs/reference/variables/AnalyticsProvider.md
@@ -6,7 +6,7 @@
 
 # Variable: AnalyticsProvider
 
-> `const` **AnalyticsProvider**: (`props`) => `Element`
+> `const` **AnalyticsProvider**: (`props`) => `ReactElement`
 
 Defined in: [src/sdk.tsx:74](https://github.com/FirebaseExtended/reactfire/blob/main/src/sdk.tsx#L74)
 
@@ -18,4 +18,4 @@ Defined in: [src/sdk.tsx:74](https://github.com/FirebaseExtended/reactfire/blob/
 
 ## Returns
 
-`Element`
+`ReactElement`

--- a/docs/reference/variables/AppCheckProvider.md
+++ b/docs/reference/variables/AppCheckProvider.md
@@ -6,7 +6,7 @@
 
 # Variable: AppCheckProvider
 
-> `const` **AppCheckProvider**: (`props`) => `Element`
+> `const` **AppCheckProvider**: (`props`) => `ReactElement`
 
 Defined in: [src/sdk.tsx:72](https://github.com/FirebaseExtended/reactfire/blob/main/src/sdk.tsx#L72)
 
@@ -18,4 +18,4 @@ Defined in: [src/sdk.tsx:72](https://github.com/FirebaseExtended/reactfire/blob/
 
 ## Returns
 
-`Element`
+`ReactElement`

--- a/docs/reference/variables/AuthProvider.md
+++ b/docs/reference/variables/AuthProvider.md
@@ -6,7 +6,7 @@
 
 # Variable: AuthProvider
 
-> `const` **AuthProvider**: (`props`) => `Element`
+> `const` **AuthProvider**: (`props`) => `ReactElement`
 
 Defined in: [src/sdk.tsx:73](https://github.com/FirebaseExtended/reactfire/blob/main/src/sdk.tsx#L73)
 
@@ -18,4 +18,4 @@ Defined in: [src/sdk.tsx:73](https://github.com/FirebaseExtended/reactfire/blob/
 
 ## Returns
 
-`Element`
+`ReactElement`

--- a/docs/reference/variables/DatabaseProvider.md
+++ b/docs/reference/variables/DatabaseProvider.md
@@ -6,7 +6,7 @@
 
 # Variable: DatabaseProvider
 
-> `const` **DatabaseProvider**: (`props`) => `Element`
+> `const` **DatabaseProvider**: (`props`) => `ReactElement`
 
 Defined in: [src/sdk.tsx:75](https://github.com/FirebaseExtended/reactfire/blob/main/src/sdk.tsx#L75)
 
@@ -18,4 +18,4 @@ Defined in: [src/sdk.tsx:75](https://github.com/FirebaseExtended/reactfire/blob/
 
 ## Returns
 
-`Element`
+`ReactElement`

--- a/docs/reference/variables/FirestoreProvider.md
+++ b/docs/reference/variables/FirestoreProvider.md
@@ -6,7 +6,7 @@
 
 # Variable: FirestoreProvider
 
-> `const` **FirestoreProvider**: (`props`) => `Element`
+> `const` **FirestoreProvider**: (`props`) => `ReactElement`
 
 Defined in: [src/sdk.tsx:76](https://github.com/FirebaseExtended/reactfire/blob/main/src/sdk.tsx#L76)
 
@@ -18,4 +18,4 @@ Defined in: [src/sdk.tsx:76](https://github.com/FirebaseExtended/reactfire/blob/
 
 ## Returns
 
-`Element`
+`ReactElement`

--- a/docs/reference/variables/FunctionsProvider.md
+++ b/docs/reference/variables/FunctionsProvider.md
@@ -6,7 +6,7 @@
 
 # Variable: FunctionsProvider
 
-> `const` **FunctionsProvider**: (`props`) => `Element`
+> `const` **FunctionsProvider**: (`props`) => `ReactElement`
 
 Defined in: [src/sdk.tsx:77](https://github.com/FirebaseExtended/reactfire/blob/main/src/sdk.tsx#L77)
 
@@ -18,4 +18,4 @@ Defined in: [src/sdk.tsx:77](https://github.com/FirebaseExtended/reactfire/blob/
 
 ## Returns
 
-`Element`
+`ReactElement`

--- a/docs/reference/variables/PerformanceProvider.md
+++ b/docs/reference/variables/PerformanceProvider.md
@@ -6,7 +6,7 @@
 
 # Variable: PerformanceProvider
 
-> `const` **PerformanceProvider**: (`props`) => `Element`
+> `const` **PerformanceProvider**: (`props`) => `ReactElement`
 
 Defined in: [src/sdk.tsx:78](https://github.com/FirebaseExtended/reactfire/blob/main/src/sdk.tsx#L78)
 
@@ -18,4 +18,4 @@ Defined in: [src/sdk.tsx:78](https://github.com/FirebaseExtended/reactfire/blob/
 
 ## Returns
 
-`Element`
+`ReactElement`

--- a/docs/reference/variables/RemoteConfigProvider.md
+++ b/docs/reference/variables/RemoteConfigProvider.md
@@ -6,7 +6,7 @@
 
 # Variable: RemoteConfigProvider
 
-> `const` **RemoteConfigProvider**: (`props`) => `Element`
+> `const` **RemoteConfigProvider**: (`props`) => `ReactElement`
 
 Defined in: [src/sdk.tsx:80](https://github.com/FirebaseExtended/reactfire/blob/main/src/sdk.tsx#L80)
 
@@ -18,4 +18,4 @@ Defined in: [src/sdk.tsx:80](https://github.com/FirebaseExtended/reactfire/blob/
 
 ## Returns
 
-`Element`
+`ReactElement`

--- a/docs/reference/variables/StorageProvider.md
+++ b/docs/reference/variables/StorageProvider.md
@@ -6,7 +6,7 @@
 
 # Variable: StorageProvider
 
-> `const` **StorageProvider**: (`props`) => `Element`
+> `const` **StorageProvider**: (`props`) => `ReactElement`
 
 Defined in: [src/sdk.tsx:79](https://github.com/FirebaseExtended/reactfire/blob/main/src/sdk.tsx#L79)
 
@@ -18,4 +18,4 @@ Defined in: [src/sdk.tsx:79](https://github.com/FirebaseExtended/reactfire/blob/
 
 ## Returns
 
-`Element`
+`ReactElement`

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -244,7 +244,7 @@ export function ClaimsCheck({ user, fallback, children, requiredClaims }: Claims
  *
  * Meant for Concurrent mode only (`<FirebaseAppProvider suspense=true />`). [More detail](https://github.com/FirebaseExtended/reactfire/issues/325#issuecomment-827654376).
  */
-export function AuthCheck({ fallback, children, requiredClaims }: AuthCheckProps): JSX.Element {
+export function AuthCheck({ fallback, children, requiredClaims }: AuthCheckProps): React.ReactElement {
   const { data: user } = useUser<User>();
 
   const suspenseMode = useSuspenseEnabledFromConfigAndContext();

--- a/src/performance.tsx
+++ b/src/performance.tsx
@@ -6,7 +6,7 @@ export interface SuspensePerfProps {
   fallback: React.ReactNode;
 }
 
-export function SuspenseWithPerf({ children, traceId, fallback }: SuspensePerfProps): JSX.Element {
+export function SuspenseWithPerf({ children, traceId, fallback }: SuspensePerfProps): React.ReactElement {
   // TODO: Should this import firebase/performance?
 
   const perf = typeof globalThis !== 'undefined' ? globalThis.performance : undefined;

--- a/src/sdk.tsx
+++ b/src/sdk.tsx
@@ -28,7 +28,7 @@ export const RemoteConfigSdkContext = React.createContext<RemoteConfig | undefin
 type FirebaseSdks = Analytics | AppCheck | Auth | Database | Firestore | FirebasePerformance | FirebaseStorage | Functions | RemoteConfig;
 
 function getSdkProvider<Sdk extends FirebaseSdks>(SdkContext: React.Context<Sdk | undefined>) {
-  return function SdkProvider(props: React.PropsWithChildren<{ sdk: Sdk }>) {
+  return function SdkProvider(props: React.PropsWithChildren<{ sdk: Sdk }>): React.ReactElement {
     if (!props.sdk) throw new Error('no sdk provided');
 
     const contextualAppName = useFirebaseApp().name;

--- a/src/storage.tsx
+++ b/src/storage.tsx
@@ -48,7 +48,7 @@ function StorageFromContext(props: StorageImageProps & React.DetailedHTMLProps<R
   return <INTERNALStorageImage {...props} />;
 }
 
-function INTERNALStorageImage(props: StorageImageProps & React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>): React.ReactElement {
+function INTERNALStorageImage(props: StorageImageProps & React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>): React.ReactNode {
   const { storage, storagePath, suspense, placeHolder, ...imgProps } = props;
 
   const reactfireOptions: ReactFireOptions<string> = {

--- a/src/storage.tsx
+++ b/src/storage.tsx
@@ -37,7 +37,7 @@ export type StorageImageProps = {
   storagePath: string;
   storage?: FirebaseStorage;
   suspense?: boolean;
-  placeHolder?: React.ReactElement;
+  placeHolder?: React.ReactNode;
 };
 
 function StorageFromContext(props: StorageImageProps & React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>) {

--- a/src/storage.tsx
+++ b/src/storage.tsx
@@ -37,7 +37,7 @@ export type StorageImageProps = {
   storagePath: string;
   storage?: FirebaseStorage;
   suspense?: boolean;
-  placeHolder?: JSX.Element;
+  placeHolder?: React.ReactElement;
 };
 
 function StorageFromContext(props: StorageImageProps & React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>) {
@@ -48,7 +48,7 @@ function StorageFromContext(props: StorageImageProps & React.DetailedHTMLProps<R
   return <INTERNALStorageImage {...props} />;
 }
 
-function INTERNALStorageImage(props: StorageImageProps & React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>): JSX.Element {
+function INTERNALStorageImage(props: StorageImageProps & React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>): React.ReactElement {
   const { storage, storagePath, suspense, placeHolder, ...imgProps } = props;
 
   const reactfireOptions: ReactFireOptions<string> = {


### PR DESCRIPTION
## Problem

Since React 19 removed \`JSX.Element\` from the global \`JSX\` namespace, components in reactfire that return \`JSX.Element\` no longer type-check with React 19 consumers:

\`\`\`
Type error: 'AuthProvider' cannot be used as a JSX component.
  Its type '(props: PropsWithChildren<{ sdk: Auth; }>) => Element' is not a valid JSX element type.
    Type 'Element' is not assignable to type 'ReactNode | Promise<ReactNode>'.
\`\`\`

## Fix

Replace all \`JSX.Element\` annotations with explicit \`React.*\` types. Changed in 4 places:

- \`src/sdk.tsx\` — \`SdkProvider\` return type → \`React.ReactElement\`
- \`src/auth.tsx\` — \`AuthCheck\` return type → \`React.ReactElement\`
- \`src/performance.tsx\` — \`SuspenseWithPerf\` return type → \`React.ReactElement\`
- \`src/storage.tsx\` — \`INTERNALStorageImage\` return type and \`placeHolder\` prop → \`React.ReactNode\` (appropriate since a placeholder can be a string, number, null, etc.)

Also adds a CI \`type-check\` matrix job that runs \`tsc\` against both \`@types/react@18\` and \`@types/react@19\` to prevent regressions.

Fixes #637