### PR TITLE
fix: update useFirestoreDocData return type to include undefined

### DIFF
--- a/docs/reference/functions/useFirestoreDocData.md
+++ b/docs/reference/functions/useFirestoreDocData.md
@@ -6,7 +6,7 @@
 
 # Function: useFirestoreDocData()
 
-> **useFirestoreDocData**\<`T`\>(`ref`, `options?`): [`ObservableStatus`](../type-aliases/ObservableStatus.md)\<`T`\>
+> **useFirestoreDocData**\<`T`\>(`ref`, `options?`): [`ObservableStatus`](../type-aliases/ObservableStatus.md)\<`T` \| `undefined`\>
 
 Defined in: [src/firestore.tsx:62](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L62)
 
@@ -30,4 +30,4 @@ Subscribe to Firestore Document changes and unwrap the document into a plain obj
 
 ## Returns
 
-[`ObservableStatus`](../type-aliases/ObservableStatus.md)\<`T`\>
+[`ObservableStatus`](../type-aliases/ObservableStatus.md)\<`T` \| `undefined`\>

--- a/docs/reference/functions/useFirestoreDocDataOnce.md
+++ b/docs/reference/functions/useFirestoreDocDataOnce.md
@@ -6,7 +6,7 @@
 
 # Function: useFirestoreDocDataOnce()
 
-> **useFirestoreDocDataOnce**\<`T`\>(`ref`, `options?`): [`ObservableStatus`](../type-aliases/ObservableStatus.md)\<`T`\>
+> **useFirestoreDocDataOnce**\<`T`\>(`ref`, `options?`): [`ObservableStatus`](../type-aliases/ObservableStatus.md)\<`T` \| `undefined`\>
 
 Defined in: [src/firestore.tsx:74](https://github.com/FirebaseExtended/reactfire/blob/main/src/firestore.tsx#L74)
 
@@ -30,4 +30,4 @@ Get a Firestore document, unwrap the document into a plain object, and don't sub
 
 ## Returns
 
-[`ObservableStatus`](../type-aliases/ObservableStatus.md)\<`T`\>
+[`ObservableStatus`](../type-aliases/ObservableStatus.md)\<`T` \| `undefined`\>

--- a/src/firestore.tsx
+++ b/src/firestore.tsx
@@ -59,7 +59,7 @@ export function useFirestoreDocOnce<T = DocumentData>(ref: DocumentReference<T>,
 /**
  * Subscribe to Firestore Document changes and unwrap the document into a plain object
  */
-export function useFirestoreDocData<T = unknown>(ref: DocumentReference<T>, options?: ReactFireOptions<T>): ObservableStatus<T> {
+export function useFirestoreDocData<T = unknown>(ref: DocumentReference<T>, options?: ReactFireOptions<T>): ObservableStatus<T | undefined> {
   const idField = options ? checkIdField(options) : 'NO_ID_FIELD';
 
   const observableId = `firestore:docData:${ref.firestore.app.name}:${ref.path}:idField=${idField}`;
@@ -71,7 +71,7 @@ export function useFirestoreDocData<T = unknown>(ref: DocumentReference<T>, opti
 /**
  * Get a Firestore document, unwrap the document into a plain object, and don't subscribe to changes
  */
-export function useFirestoreDocDataOnce<T = unknown>(ref: DocumentReference<T>, options?: ReactFireOptions<T>): ObservableStatus<T> {
+export function useFirestoreDocDataOnce<T = unknown>(ref: DocumentReference<T>, options?: ReactFireOptions<T>): ObservableStatus<T | undefined> {
   const idField = options ? checkIdField(options) : 'NO_ID_FIELD';
 
   const observableId = `firestore:docDataOnce:${ref.firestore.app.name}:${ref.path}:idField=${idField}`;


### PR DESCRIPTION
## Problem

`useFirestoreDocData` and `useFirestoreDocDataOnce` were declared to return `ObservableStatus<T>`, but `docData()` from rxfire returns `Observable<T | undefined>` because a Firestore document may not exist. This meant callers could access `data.someProperty` without any type-level warning, only to get a runtime error when `data` was `undefined`.

## Fix

Update the return types to `ObservableStatus<T | undefined>`, which accurately reflects what the observable emits. The discriminated union in `ObservableStatus` already handles this correctly — `status: 'loading'` has `data: undefined`, `status: 'success'` has `data: T | undefined` for these hooks.

TypeScript now correctly flags:
```ts
const { data } = useFirestoreDocData(ref);
data.someProperty; // TS18048: 'data' is possibly 'undefined'

// Narrowing works as expected:
if (status === 'success' && data) {
  data.someProperty; // OK
}
```

Fixes #577