### PR TITLE
docs: fix emulator setup example to prevent double-initialization

### DIFF
--- a/docs/use.md
+++ b/docs/use.md
@@ -97,9 +97,7 @@ SDK not found. useSdk must be called from within a provider
 
 ### Connect to the Firebase Local Emulator Suite
 
-Connect emulators to the SDK instances **before** passing them to providers, and ensure the connect calls only run once. Calling `connect*Emulator()` inside a React component body without a guard will throw on re-renders (`Firestore has already been started and its settings can no longer be changed`).
-
-The safest pattern is to initialize outside of React entirely:
+Connect emulators to the SDK instances **before** passing them to providers. The safest pattern is to initialize outside of React entirely, which guarantees `connect*Emulator()` only runs once, regardless of re-renders or remounts:
 
 ```jsx
 import { initializeApp } from 'firebase/app';
@@ -128,37 +126,6 @@ function App() {
         </FirestoreProvider>
       </AuthProvider>
     </FirebaseAppProvider>
-  );
-}
-```
-
-If you need to initialize inside a component (e.g. to access `useFirebaseApp()`), use a ref to ensure the connect calls only happen once:
-
-```jsx
-import { useRef } from 'react';
-import { getAuth, connectAuthEmulator } from 'firebase/auth';
-import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
-
-import { FirebaseAppProvider, FirestoreProvider, AuthProvider, useFirebaseApp } from 'reactfire';
-
-function FirebaseComponents({ children }) {
-  const app = useFirebaseApp();
-  const auth = getAuth(app);
-  const firestore = getFirestore(app);
-
-  const connected = useRef(false);
-  if (!connected.current && process.env.NODE_ENV !== 'production') {
-    connected.current = true;
-    connectAuthEmulator(auth, 'http://localhost:9099');
-    connectFirestoreEmulator(firestore, 'localhost', 8080);
-  }
-
-  return (
-    <AuthProvider sdk={auth}>
-      <FirestoreProvider sdk={firestore}>
-        {children}
-      </FirestoreProvider>
-    </AuthProvider>
   );
 }
 ```

--- a/docs/use.md
+++ b/docs/use.md
@@ -97,32 +97,67 @@ SDK not found. useSdk must be called from within a provider
 
 ### Connect to the Firebase Local Emulator Suite
 
-Connect a product SDK to the emulator before passing it to a provider. For example, to connect to the Auth and Realtime Database emulators:
+Connect emulators to the SDK instances **before** passing them to providers, and ensure the connect calls only run once. Calling `connect*Emulator()` inside a React component body without a guard will throw on re-renders (`Firestore has already been started and its settings can no longer be changed`).
+
+The safest pattern is to initialize outside of React entirely:
 
 ```jsx
-import { getAuth, connectAuthEmulator } from 'firebase/auth'; // Firebase v9+
-import { getDatabase, connectDatabaseEmulator } from 'firebase/database'; // Firebase v9+
+import { initializeApp } from 'firebase/app';
+import { getAuth, connectAuthEmulator } from 'firebase/auth';
+import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
 
-import { FirebaseAppProvider, DatabaseProvider, AuthProvider, useFirebaseApp } from 'reactfire';
+import { FirebaseAppProvider, FirestoreProvider, AuthProvider } from 'reactfire';
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const firestore = getFirestore(app);
+
+// Check for dev/test mode however your app tracks that.
+// `process.env.NODE_ENV` is a common React pattern
+if (process.env.NODE_ENV !== 'production') {
+  connectAuthEmulator(auth, 'http://localhost:9099');
+  connectFirestoreEmulator(firestore, 'localhost', 8080);
+}
+
+function App() {
+  return (
+    <FirebaseAppProvider firebaseApp={app}>
+      <AuthProvider sdk={auth}>
+        <FirestoreProvider sdk={firestore}>
+          <MyCoolApp />
+        </FirestoreProvider>
+      </AuthProvider>
+    </FirebaseAppProvider>
+  );
+}
+```
+
+If you need to initialize inside a component (e.g. to access `useFirebaseApp()`), use a ref to ensure the connect calls only happen once:
+
+```jsx
+import { useRef } from 'react';
+import { getAuth, connectAuthEmulator } from 'firebase/auth';
+import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
+
+import { FirebaseAppProvider, FirestoreProvider, AuthProvider, useFirebaseApp } from 'reactfire';
 
 function FirebaseComponents({ children }) {
   const app = useFirebaseApp();
-  const database = getDatabase(app);
   const auth = getAuth(app);
+  const firestore = getFirestore(app);
 
-  // Check for dev/test mode however your app tracks that.
-  // `process.env.NODE_ENV` is a common React pattern
-  if (process.env.NODE_ENV !== 'production') {
-    // Set up emulators
-    connectDatabaseEmulator(database, 'localhost', 9000);
+  const connected = useRef(false);
+  if (!connected.current && process.env.NODE_ENV !== 'production') {
+    connected.current = true;
     connectAuthEmulator(auth, 'http://localhost:9099');
+    connectFirestoreEmulator(firestore, 'localhost', 8080);
   }
 
   return (
     <AuthProvider sdk={auth}>
-      <DatabaseProvider sdk={database}>
-        <MyCoolAppThatUsesAuthAndRealtimeDatabase />
-      </DatabaseProvider>
+      <FirestoreProvider sdk={firestore}>
+        {children}
+      </FirestoreProvider>
     </AuthProvider>
   );
 }

--- a/docs/use.md
+++ b/docs/use.md
@@ -130,6 +130,8 @@ function App() {
 }
 ```
 
+This pattern requires passing `firebaseApp={app}` to `FirebaseAppProvider` so you own the app instance at module level. If you are currently using `firebaseConfig={...}` on `FirebaseAppProvider`, switch to initializing the app yourself with `initializeApp()` and passing it via `firebaseApp=`. The `firebaseConfig=` prop is a convenience shortcut, but it gives reactfire ownership of the app instance, which makes emulator setup (and anything else that needs the app before React renders) unnecessarily difficult.
+
 Learn more about the Local Emulator Suite in the [Firebase docs](https://firebase.google.com/docs/emulator-suite/connect_and_prototype).
 
 ### Set up App Check


### PR DESCRIPTION
## Problem

The emulator setup example in use.md called `connect*Emulator()` inside a React component body without any guard. This causes the following error on re-renders (React StrictMode, parent re-renders, Next.js page transitions):

> FirebaseError: Firestore has already been started and its settings can no longer be changed. You can only modify settings before calling any other methods on a Firestore object.

This is the root cause behind all the workarounds in #459 (`_settingsFrozen` checks, `window['_init']` flags, etc.) — users were working around bad docs.

## Fix

Replace the broken component-level example with module-level initialization: create the app and SDK instances outside React, connect emulators there, then pass everything into providers via `firebaseApp=`. This guarantees `connect*Emulator()` only runs once.

Also adds a note explaining that `firebaseConfig=` on `FirebaseAppProvider` is a convenience shortcut that gives reactfire ownership of the app instance, making emulator setup unnecessarily difficult. Prefer `firebaseApp=` for anything non-trivial.

Fixes #459