### PR TITLE
fix: tighten ReactFireOptions generic types, remove T | any widening

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+src/*.type-test.ts

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Firebase.
 
 ## Platform support
 
-ReactFire is designed for **web React apps** and wraps the [Firebase Web SDK](https://firebase.google.com/docs/web/setup). It is not compatible with React Native or Expo. For React Native projects, use [react-native-firebase](https://rnfirebase.io/) instead.
+ReactFire is designed for **web React apps** and wraps the [Firebase JavaScript SDK](https://firebase.google.com/docs/web/setup). It is not compatible with React Native or Expo. For React Native projects, use [react-native-firebase](https://rnfirebase.io/) instead.
 
 ## Install
 

--- a/docs/reference/functions/checkIdField.md
+++ b/docs/reference/functions/checkIdField.md
@@ -6,9 +6,9 @@
 
 # Function: checkIdField()
 
-> **checkIdField**(`options`): `any`
+> **checkIdField**(`options`): `string` \| `undefined`
 
-Defined in: [src/index.ts:47](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L47)
+Defined in: [src/index.ts:50](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L50)
 
 ## Parameters
 
@@ -18,4 +18,4 @@ Defined in: [src/index.ts:47](https://github.com/FirebaseExtended/reactfire/blob
 
 ## Returns
 
-`any`
+`string` \| `undefined`

--- a/docs/reference/functions/checkOptions.md
+++ b/docs/reference/functions/checkOptions.md
@@ -6,9 +6,9 @@
 
 # Function: checkOptions()
 
-> **checkOptions**(`options`, `field`): `any`
+> **checkOptions**(`options`, `field`): `unknown`
 
-Defined in: [src/index.ts:34](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L34)
+Defined in: [src/index.ts:37](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L37)
 
 ## Parameters
 
@@ -22,4 +22,4 @@ Defined in: [src/index.ts:34](https://github.com/FirebaseExtended/reactfire/blob
 
 ## Returns
 
-`any`
+`unknown`

--- a/docs/reference/functions/checkinitialData.md
+++ b/docs/reference/functions/checkinitialData.md
@@ -6,9 +6,9 @@
 
 # Function: checkinitialData()
 
-> **checkinitialData**(`options`): `any`
+> **checkinitialData**(`options`): `unknown`
 
-Defined in: [src/index.ts:43](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L43)
+Defined in: [src/index.ts:46](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L46)
 
 ## Parameters
 
@@ -18,4 +18,4 @@ Defined in: [src/index.ts:43](https://github.com/FirebaseExtended/reactfire/blob
 
 ## Returns
 
-`any`
+`unknown`

--- a/docs/reference/functions/useFirestoreCollection.md
+++ b/docs/reference/functions/useFirestoreCollection.md
@@ -26,7 +26,7 @@ Subscribe to a Firestore collection
 
 ### options?
 
-[`ReactFireOptions`](../interfaces/ReactFireOptions.md)\<`T`[]\>
+[`ReactFireOptions`](../interfaces/ReactFireOptions.md)\<`QuerySnapshot`\<`T`, `DocumentData`\>\>
 
 ## Returns
 

--- a/docs/reference/functions/useFirestoreDoc.md
+++ b/docs/reference/functions/useFirestoreDoc.md
@@ -28,7 +28,7 @@ You can preload data for this hook by calling `preloadFirestoreDoc`
 
 ### options?
 
-[`ReactFireOptions`](../interfaces/ReactFireOptions.md)\<`T`\>
+[`ReactFireOptions`](../interfaces/ReactFireOptions.md)\<`DocumentSnapshot`\<`T`, `DocumentData`\>\>
 
 ## Returns
 

--- a/docs/reference/functions/useFirestoreDocOnce.md
+++ b/docs/reference/functions/useFirestoreDocOnce.md
@@ -26,7 +26,7 @@ Get a firestore document and don't subscribe to changes
 
 ### options?
 
-[`ReactFireOptions`](../interfaces/ReactFireOptions.md)\<`T`\>
+[`ReactFireOptions`](../interfaces/ReactFireOptions.md)\<`DocumentSnapshot`\<`T`, `DocumentData`\>\>
 
 ## Returns
 

--- a/docs/reference/interfaces/ReactFireOptions.md
+++ b/docs/reference/interfaces/ReactFireOptions.md
@@ -30,7 +30,7 @@ Defined in: [src/index.ts:25](https://github.com/FirebaseExtended/reactfire/blob
 
 ### initialData?
 
-> `optional` **initialData?**: `any`
+> `optional` **initialData?**: `T`
 
 Defined in: [src/index.ts:26](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L26)
 
@@ -38,7 +38,7 @@ Defined in: [src/index.ts:26](https://github.com/FirebaseExtended/reactfire/blob
 
 ### ~~startWithValue?~~
 
-> `optional` **startWithValue?**: `any`
+> `optional` **startWithValue?**: `T`
 
 Defined in: [src/index.ts:30](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L30)
 

--- a/docs/reference/interfaces/SignInCheckOptionsBasic.md
+++ b/docs/reference/interfaces/SignInCheckOptionsBasic.md
@@ -41,7 +41,7 @@ Defined in: [src/index.ts:25](https://github.com/FirebaseExtended/reactfire/blob
 
 ### initialData?
 
-> `optional` **initialData?**: `any`
+> `optional` **initialData?**: [`SigninCheckResult`](../type-aliases/SigninCheckResult.md)
 
 Defined in: [src/index.ts:26](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L26)
 
@@ -53,7 +53,7 @@ Defined in: [src/index.ts:26](https://github.com/FirebaseExtended/reactfire/blob
 
 ### ~~startWithValue?~~
 
-> `optional` **startWithValue?**: `any`
+> `optional` **startWithValue?**: [`SigninCheckResult`](../type-aliases/SigninCheckResult.md)
 
 Defined in: [src/index.ts:30](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L30)
 

--- a/docs/reference/interfaces/SignInCheckOptionsClaimsObject.md
+++ b/docs/reference/interfaces/SignInCheckOptionsClaimsObject.md
@@ -40,7 +40,7 @@ Defined in: [src/index.ts:25](https://github.com/FirebaseExtended/reactfire/blob
 
 ### initialData?
 
-> `optional` **initialData?**: `any`
+> `optional` **initialData?**: [`SigninCheckResult`](../type-aliases/SigninCheckResult.md)
 
 Defined in: [src/index.ts:26](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L26)
 
@@ -60,7 +60,7 @@ Defined in: [src/auth.tsx:90](https://github.com/FirebaseExtended/reactfire/blob
 
 ### ~~startWithValue?~~
 
-> `optional` **startWithValue?**: `any`
+> `optional` **startWithValue?**: [`SigninCheckResult`](../type-aliases/SigninCheckResult.md)
 
 Defined in: [src/index.ts:30](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L30)
 

--- a/docs/reference/interfaces/SignInCheckOptionsClaimsValidator.md
+++ b/docs/reference/interfaces/SignInCheckOptionsClaimsValidator.md
@@ -40,7 +40,7 @@ Defined in: [src/index.ts:25](https://github.com/FirebaseExtended/reactfire/blob
 
 ### initialData?
 
-> `optional` **initialData?**: `any`
+> `optional` **initialData?**: [`SigninCheckResult`](../type-aliases/SigninCheckResult.md)
 
 Defined in: [src/index.ts:26](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L26)
 
@@ -52,7 +52,7 @@ Defined in: [src/index.ts:26](https://github.com/FirebaseExtended/reactfire/blob
 
 ### ~~startWithValue?~~
 
-> `optional` **startWithValue?**: `any`
+> `optional` **startWithValue?**: [`SigninCheckResult`](../type-aliases/SigninCheckResult.md)
 
 Defined in: [src/index.ts:30](https://github.com/FirebaseExtended/reactfire/blob/main/src/index.ts#L30)
 

--- a/src/firestore.tsx
+++ b/src/firestore.tsx
@@ -39,7 +39,7 @@ function getDocObservableId<T = DocumentData>(ref: DocumentReference<T>) {
  *
  * You can preload data for this hook by calling `preloadFirestoreDoc`
  */
-export function useFirestoreDoc<T = DocumentData>(ref: DocumentReference<T>, options?: ReactFireOptions<T>): ObservableStatus<DocumentSnapshot<T>> {
+export function useFirestoreDoc<T = DocumentData>(ref: DocumentReference<T>, options?: ReactFireOptions<DocumentSnapshot<T>>): ObservableStatus<DocumentSnapshot<T>> {
   const observableId = getDocObservableId(ref);
   const observable$ = doc(ref);
 
@@ -49,7 +49,7 @@ export function useFirestoreDoc<T = DocumentData>(ref: DocumentReference<T>, opt
 /**
  * Get a firestore document and don't subscribe to changes
  */
-export function useFirestoreDocOnce<T = DocumentData>(ref: DocumentReference<T>, options?: ReactFireOptions<T>): ObservableStatus<DocumentSnapshot<T>> {
+export function useFirestoreDocOnce<T = DocumentData>(ref: DocumentReference<T>, options?: ReactFireOptions<DocumentSnapshot<T>>): ObservableStatus<DocumentSnapshot<T>> {
   const observableId = `firestore:docOnce:${ref.firestore.app.name}:${ref.path}`;
   const observable$ = doc(ref).pipe(first());
 
@@ -63,7 +63,7 @@ export function useFirestoreDocData<T = unknown>(ref: DocumentReference<T>, opti
   const idField = options ? checkIdField(options) : undefined;
 
   const observableId = `firestore:docData:${ref.firestore.app.name}:${ref.path}:idField=${JSON.stringify(idField)}`;
-  const observable = docData(ref, { idField });
+  const observable = docData(ref, { idField: idField as keyof T });
 
   return useObservable(observableId, observable, options) as ObservableStatus<T>;
 }
@@ -75,7 +75,7 @@ export function useFirestoreDocDataOnce<T = unknown>(ref: DocumentReference<T>, 
   const idField = options ? checkIdField(options) : undefined;
 
   const observableId = `firestore:docDataOnce:${ref.firestore.app.name}:${ref.path}:idField=${JSON.stringify(idField)}`;
-  const observable$ = docData(ref, { idField }).pipe(first());
+  const observable$ = docData(ref, { idField: idField as keyof T }).pipe(first());
 
   return useObservable(observableId, observable$, options) as ObservableStatus<T>;
 }
@@ -83,7 +83,7 @@ export function useFirestoreDocDataOnce<T = unknown>(ref: DocumentReference<T>, 
 /**
  * Subscribe to a Firestore collection
  */
-export function useFirestoreCollection<T = DocumentData>(query: FirestoreQuery<T>, options?: ReactFireOptions<T[]>): ObservableStatus<QuerySnapshot<T>> {
+export function useFirestoreCollection<T = DocumentData>(query: FirestoreQuery<T>, options?: ReactFireOptions<QuerySnapshot<T>>): ObservableStatus<QuerySnapshot<T>> {
   const observableId = `firestore:collection:${getUniqueIdForFirestoreQuery(query)}`;
   const observable$ = fromRef(query);
 
@@ -96,7 +96,7 @@ export function useFirestoreCollection<T = DocumentData>(query: FirestoreQuery<T
 export function useFirestoreCollectionData<T = DocumentData>(query: FirestoreQuery<T>, options?: ReactFireOptions<T[]>): ObservableStatus<T[]> {
   const idField = options ? checkIdField(options) : undefined;
   const observableId = `firestore:collectionData:${getUniqueIdForFirestoreQuery(query)}:idField=${JSON.stringify(idField)}`;
-  const observable$ = collectionData(query, { idField });
+  const observable$ = collectionData(query, { idField: idField as (string & keyof T) });
 
   return useObservable(observableId, observable$, options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,14 +23,17 @@ export class ReactFireError extends Error {
 
 export interface ReactFireOptions<T = unknown> {
   idField?: string;
-  initialData?: T | any;
+  initialData?: T;
   /**
    * @deprecated use initialData instead
    */
-  startWithValue?: T | any;
+  startWithValue?: T;
   suspense?: boolean;
 }
 
+// Deprecated: unused internally as of the ReactFireOptions generic tightening.
+// Removal is tracked in #754 alongside the other deprecated exports, so it
+// lands as its own change rather than inside this one.
 export function checkOptions(options: ReactFireOptions, field: string) {
   // make sure the field passed in is a valid key of ReactFire Options
   if (field === 'idField' || field === 'initialData' || field === 'suspense') {
@@ -44,8 +47,8 @@ export function checkinitialData(options: ReactFireOptions) {
   return checkOptions(options, 'initialData');
 }
 
-export function checkIdField(options: ReactFireOptions) {
-  return checkOptions(options, 'idField');
+export function checkIdField(options: ReactFireOptions): string | undefined {
+  return options?.idField;
 }
 
 export * from './auth';

--- a/src/reactfire-options.type-test.ts
+++ b/src/reactfire-options.type-test.ts
@@ -1,0 +1,46 @@
+/**
+ * Type-level regression tests for ReactFireOptions<T> generic constraints.
+ * Checked by `tsc --noEmit` in CI. No runtime behavior — not bundled.
+ */
+import type { ReactFireOptions } from './index';
+
+// ---- initialData must match T ----
+
+void ((): ReactFireOptions<string> => ({ initialData: 'hello' }))();
+void ((): ReactFireOptions<number> => ({ initialData: 42 }))();
+
+// @ts-expect-error initialData must be T, not a different type
+const _wrongInitialData: ReactFireOptions<string> = { initialData: 123 };
+void _wrongInitialData;
+
+// @ts-expect-error startWithValue must be T, not a different type
+const _wrongStartWithValue: ReactFireOptions<string> = { startWithValue: 123 };
+void _wrongStartWithValue;
+
+// ---- snapshot hooks take the snapshot, data hooks take the data (#741) ----
+//
+// Removing `T | any` also removed what was masking a mismatch: the raw snapshot
+// hooks resolve to a DocumentSnapshot/QuerySnapshot, so that is what a correct
+// initialData is. Without the hook-level fix, seeding them with a snapshot (the
+// only value you can actually have) stops compiling.
+
+import type { DocumentReference, DocumentSnapshot, Query, QuerySnapshot } from 'firebase/firestore';
+import type { useFirestoreCollection, useFirestoreDoc, useFirestoreDocData } from './firestore';
+
+declare const ref: DocumentReference<{ a: string }>;
+declare const query: Query<{ a: string }>;
+declare const snap: DocumentSnapshot<{ a: string }>;
+declare const querySnap: QuerySnapshot<{ a: string }>;
+declare const docHook: typeof useFirestoreDoc;
+declare const collectionHook: typeof useFirestoreCollection;
+declare const dataHook: typeof useFirestoreDocData;
+
+void (() => docHook(ref, { initialData: snap }));
+void (() => collectionHook(query, { initialData: querySnap }));
+void (() => dataHook(ref, { initialData: { a: 'x' } }));
+
+// @ts-expect-error a snapshot hook must not accept the unwrapped data type
+void (() => docHook(ref, { initialData: { a: 'x' } }));
+
+// @ts-expect-error a data hook must not accept a snapshot
+void (() => dataHook(ref, { initialData: snap }));


### PR DESCRIPTION
## Summary

Fixes #383. Fixes #741.

- Removes `| any` from `initialData` and `startWithValue` in `ReactFireOptions<T>`, so a value of the wrong type is a TypeScript error rather than silently accepted
- Types the raw snapshot hooks' options with the hook's own resolved type (#741), so seeding them with a snapshot still compiles
- Tightens `checkIdField` to read `options?.idField` directly instead of routing through `checkOptions`
- Narrows the return type of `checkOptions` and `checkinitialData` from `any` to `unknown`. **Both are kept as exports**; removal is #754
- Adds casts at the rxfire `docData` / `collectionData` call sites, where rxfire expects `keyof T` and the field is a plain `string`. A pre-existing gap in rxfire's types that `T | any` was masking
- Adds `src/reactfire-options.type-test.ts`, assertions riding the existing `tsc --noEmit` CI on both React majors, kept out of the tarball by `.npmignore`

No runtime change.

## What breaks

`T | any` collapses to `any`, so the generic never enforced anything. Tightening it is what #383 asks for. Three consumer-visible effects:

1. **Wrong-typed `initialData` / `startWithValue` now errors.** This is the point: it catches incorrect code.
2. **`checkOptions` and `checkinitialData` return `unknown` instead of `any`**, so a caller using the result has to narrow it.
3. **`checkIdField` returns `string | undefined` instead of `any`.** Same class, strictly more accurate.

All three are compile-time only. JavaScript consumers are unaffected.

## What does not break, thanks to #741

Tightening `initialData` to `T` is right for the data hooks and wrong for the raw snapshot hooks, which resolve to a `DocumentSnapshot<T>` / `QuerySnapshot<T>`. Left alone it would have broken **correct** code:

```ts
// would have stopped compiling
useFirestoreDoc(ref, { initialData: someDocumentSnapshot });
```

#741 is fixed here rather than deferred. Three signatures, no runtime change:

```ts
useFirestoreDoc<T>(ref, options?: ReactFireOptions<DocumentSnapshot<T>>)
useFirestoreDocOnce<T>(ref, options?: ReactFireOptions<DocumentSnapshot<T>>)
useFirestoreCollection<T>(query, options?: ReactFireOptions<QuerySnapshot<T>>)
```

Both wrong directions stay rejected: a snapshot hook refuses raw data, a data hook refuses a snapshot.

## Why a minor, not a patch

Nothing here breaks correct code, so this does not need the major. But a TypeScript consumer with a wrong `initialData` will see their build fail, and **shipping type changes in a patch is what 4.2.4 did, which is why #749 exists**. 4.3.0 is the honest label.

@jhuleatt the semver call is yours. This was briefly retargeted to `v5` earlier today, on the basis that it broke correct code; #741 removed that, so it is back on `main`. If you would rather it ride the major anyway, say so, and the cost to name is that #383 then waits until November.

## The type tests fail on a regression

An earlier version of `reactfire-options.type-test.ts` passed whether or not the tightening was in place: with `noUnusedLocals`, each unused negative-case const carried its own `TS6133`, which kept the `@ts-expect-error` satisfied even when the type error disappeared. Consuming each const fixes it, and that is what is committed. Caught by @armando-navarro.

Mutation-verified both ways:

- reverting `initialData?: T` to `initialData?: T | any` fails with `TS2578: Unused '@ts-expect-error' directive`
- reverting the three snapshot-hook signatures fails the #741 assertions with 2 errors

## Test plan

- [ ] `npm test`
- [ ] `npx tsc --noEmit` on both tsconfigs
- [ ] Reference docs regenerated with `npm run docs:fork`
