### PR TITLE
fix: externalize useSyncExternalStore shim to fix App Router crash

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,12 @@ console.log(`ReactFire v${version}`);
 
 const externals = [
   'react',
+  // Externalize the useSyncExternalStore shim so the consumer's bundler resolves it.
+  // Bundling this CJS module into the ESM output makes rolldown emit a dynamic require()
+  // that throws ("dynamic usage of require is not supported") when a reactfire data hook
+  // loads client-side in a Next.js App Router (strict ESM) context. Externalizing keeps
+  // the shim's React 16/17 fallback intact while removing the require from our dist.
+  'use-sync-external-store/shim',
   'firebase',
   'firebase/app',
   'firebase/firestore',


### PR DESCRIPTION
Fixes #759

### Summary

Reactfire **4.2.4 and 4.2.5** crash on the client whenever a data hook renders, in any browser bundle that does not expose `require`. `use-sync-external-store/shim` (CJS) gets bundled into our ESM `dist`, which makes the bundler emit a dynamic `require()`. In a strict-ESM browser context that throws at module evaluation:

```
Calling `require` for "react" in an environment that doesn't expose the `require` function
```

4.2.3 predates the current build toolchain and is clean.

### Fix

Add `use-sync-external-store/shim` to the Vite `externals` so the consumer's bundler resolves it (it is already a runtime `dependency`). This removes the `require` from our dist while keeping the shim's React 16/17 fallback, so it stays non-breaking (no peer-range change).

### Verification

- Built ESM `dist/index.js`: `require` occurrences 3 to 0; clean `import ... from "use-sync-external-store/shim"`.
- Reproduced the live crash with published 4.2.5 in two setups: a Next 16 App Router app (turbopack) and a Vite SPA (both crash client-side at module evaluation).
- Rebuilt both against this fix: Next client chunk no longer carries the throw path; the Vite app renders successfully (hook reaches `status: 'success'`).

Patch-level, non-breaking. Fixes the regression in `latest`. Version bump to 4.2.6 left as a separate publish-time commit, per convention.