### PR TITLE
fix(types): use explicit .js extensions in relative imports

### DIFF
--- a/src/SuspenseSubject.ts
+++ b/src/SuspenseSubject.ts
@@ -1,6 +1,6 @@
 import { empty, Observable, Subject, Subscriber, Subscription } from 'rxjs';
 import { catchError, shareReplay, tap } from 'rxjs/operators';
-import { ObservableStatus } from './useObservable';
+import { ObservableStatus } from './useObservable.js';
 
 export class SuspenseSubject<T> extends Subject<T> {
   private _value: T | undefined;

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { user } from 'rxfire/auth';
-import { preloadObservable, ReactFireOptions, useAuth, useObservable, ObservableStatus, ReactFireError } from './';
+import { preloadObservable, ReactFireOptions, useAuth, useObservable, ObservableStatus, ReactFireError } from './index.js';
 import { from, of, defer } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
-import { useSuspenseEnabledFromConfigAndContext } from './firebaseApp';
+import { useSuspenseEnabledFromConfigAndContext } from './firebaseApp.js';
 
 import type { Auth, User, IdTokenResult } from 'firebase/auth';
 type Claims = IdTokenResult['claims'];

--- a/src/database.tsx
+++ b/src/database.tsx
@@ -1,5 +1,5 @@
 import { list, object, QueryChange, listVal, objectVal } from 'rxfire/database';
-import { ReactFireOptions, useObservable, checkIdField, ObservableStatus, ReactFireGlobals } from './';
+import { ReactFireOptions, useObservable, checkIdField, ObservableStatus, ReactFireGlobals } from './index.js';
 
 import type { Query as DatabaseQuery, DatabaseReference } from 'firebase/database';
 

--- a/src/firestore.tsx
+++ b/src/firestore.tsx
@@ -1,6 +1,6 @@
 import { collectionData, doc, docData, fromRef } from 'rxfire/firestore';
-import { ReactFireOptions, useObservable, checkIdField, ReactFireGlobals } from './';
-import { preloadObservable, ObservableStatus } from './useObservable';
+import { ReactFireOptions, useObservable, checkIdField, ReactFireGlobals } from './index.js';
+import { preloadObservable, ObservableStatus } from './useObservable.js';
 import { first } from 'rxjs/operators';
 
 import { Query as FirestoreQuery, QuerySnapshot, DocumentReference, queryEqual, DocumentData, DocumentSnapshot } from 'firebase/firestore';

--- a/src/functions.tsx
+++ b/src/functions.tsx
@@ -1,7 +1,7 @@
 import { httpsCallable as rxHttpsCallable } from 'rxfire/functions';
 import { defer } from 'rxjs';
-import { ReactFireOptions, useObservable, ObservableStatus } from './';
-import { useFunctions } from '.';
+import { ReactFireOptions, useObservable, ObservableStatus } from './index.js';
+import { useFunctions } from './index.js';
 
 import type { HttpsCallableOptions } from 'firebase/functions';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { SuspenseSubject } from './SuspenseSubject';
+import { SuspenseSubject } from './SuspenseSubject.js';
 
 import type { Query as FirestoreQuery } from 'firebase/firestore';
 import type { Query as DatabaseQuery } from 'firebase/database';
@@ -48,13 +48,13 @@ export function checkIdField(options: ReactFireOptions) {
   return checkOptions(options, 'idField');
 }
 
-export * from './auth';
-export * from './database';
-export * from './firebaseApp';
-export * from './firestore';
-export * from './functions';
-export * from './performance';
-export * from './remote-config';
-export * from './storage';
-export * from './useObservable';
-export * from './sdk';
+export * from './auth.js';
+export * from './database.js';
+export * from './firebaseApp.js';
+export * from './firestore.js';
+export * from './functions.js';
+export * from './performance.js';
+export * from './remote-config.js';
+export * from './storage.js';
+export * from './useObservable.js';
+export * from './sdk.js';

--- a/src/remote-config.tsx
+++ b/src/remote-config.tsx
@@ -1,5 +1,5 @@
-import { useRemoteConfig } from './';
-import { useObservable, ObservableStatus } from './useObservable';
+import { useRemoteConfig } from './index.js';
+import { useObservable, ObservableStatus } from './useObservable.js';
 import { getValue, getString, getBoolean, getNumber, getAll, AllParameters } from 'rxfire/remote-config';
 import { Observable } from 'rxjs';
 

--- a/src/sdk.tsx
+++ b/src/sdk.tsx
@@ -9,11 +9,11 @@ import type { Functions } from 'firebase/functions';
 import type { FirebasePerformance } from 'firebase/performance';
 import type { FirebaseStorage } from 'firebase/storage';
 import type { RemoteConfig } from 'firebase/remote-config';
-import { useFirebaseApp } from './firebaseApp';
+import { useFirebaseApp } from './firebaseApp.js';
 import { FirebaseApp } from 'firebase/app';
-import { ObservableStatus, useObservable } from './useObservable';
+import { ObservableStatus, useObservable } from './useObservable.js';
 import { from } from 'rxjs';
-import { ReactFireOptions } from '.';
+import { ReactFireOptions } from './index.js';
 
 export const AppCheckSdkContext = React.createContext<AppCheck | undefined>(undefined);
 export const AuthSdkContext = React.createContext<Auth | undefined>(undefined);

--- a/src/storage.tsx
+++ b/src/storage.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { getDownloadURL, fromTask } from 'rxfire/storage';
 import { defer } from 'rxjs';
-import { ReactFireOptions, useObservable, ObservableStatus, useStorage } from './';
-import { useSuspenseEnabledFromConfigAndContext } from './firebaseApp';
+import { ReactFireOptions, useObservable, ObservableStatus, useStorage } from './index.js';
+import { useSuspenseEnabledFromConfigAndContext } from './firebaseApp.js';
 import { ref } from 'firebase/storage';
 
 import type { UploadTask, UploadTaskSnapshot, StorageReference, FirebaseStorage } from 'firebase/storage';

--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import { Observable } from 'rxjs';
-import { SuspenseSubject } from './SuspenseSubject';
-import { useSuspenseEnabledFromConfigAndContext } from './firebaseApp';
-import { ReactFireGlobals, ReactFireOptions } from './';
+import { SuspenseSubject } from './SuspenseSubject.js';
+import { useSuspenseEnabledFromConfigAndContext } from './firebaseApp.js';
+import { ReactFireGlobals, ReactFireOptions } from './index.js';
 
 const DEFAULT_TIMEOUT = 30_000;
 


### PR DESCRIPTION
## Summary

Fixes #769. Adds explicit `.js` extensions to relative import specifiers in `src`, so the emitted `.d.ts` stop carrying extensionless paths that `node16` / `nodenext` resolution rejects.

Source-only change, 10 files, all mechanical. `moduleResolution: bundler` accepts both forms, so nothing changes for the build or for bundler consumers.

## The bug

TypeScript emits relative specifiers unchanged, so `export * from './auth'` in `src/index.ts` becomes `from './auth'` in `dist/index.d.ts`. Under `node16` that is not a valid specifier, and a consumer on `"moduleResolution": "node16"` gets resolution errors reading our declarations.

Two shapes were involved:

- **16 extensionless relative imports across 10 emitted `.d.ts` files** (`from './useObservable'`)
- **6 bare directory specifiers**, `from './'` and `from '.'`, in `auth`, `database`, `firestore`, `functions`, `remote-config`, `sdk`, `storage` and `useObservable`. These resolve to the barrel and now point at `./index.js` explicitly

The runtime bundles resolve fine, which is why nothing in the build caught it.

## Verification

`@arethetypeswrong/cli` against the packed build, **with no ignore rules**:

| | before | after |
| --- | --- | --- |
| node10 | pass | pass |
| node16 (from CJS) | no types | no types |
| node16 (from ESM) | **internal resolution error** | **pass** |
| bundler | pass | pass |

The remaining `node16 (from CJS)` failure is a different bug: no `types` condition on either `exports` branch, fixed in #766. **Applying both, all four modes pass with no suppression**, which is the acceptance test #769 asks for.

Also confirmed: `tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.test.json`, `vite build` succeeds, and zero extensionless relative specifiers remain in the emitted declarations.

## Relationship to #766

#766 adds `attw` to CI and currently suppresses this via `.attw.json`:

```json
{ "ignoreRules": ["internal-resolution-error"] }
```

That ignore is rule-global, so it hides any future error of the class. **If this lands first, #766 can drop the ignore before it merges** and the suppression never ships. If #766 lands first, deleting the entry becomes this issue's acceptance test instead. Either order works; this one is tidier.

## Test plan

- [ ] `npm test`
- [ ] `npx tsc --noEmit` on both tsconfigs
- [ ] `attw` on the packed build shows no internal resolution error
