### PR TITLE
chore: gitignore CLAUDE.local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+CLAUDE.local*
 .DS_Store
 npm-debug.log
 


### PR DESCRIPTION
One line, matching `v5`'s `.gitignore` exactly.

`v5` already ignores `CLAUDE.local*` (line 1); `main` does not. On any main-based branch a local `CLAUDE.local.md` is therefore untracked but unignored: it clutters `git status` and `git clean` deletes it. Adding the same line in the same position keeps the forward-integration of `main` into `v5` a no-op.