### PR TITLE
docs: replace the concurrent mode note with a Suspense section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Firebase.
   auth state, realtime data, and all other Firebase SDK events. Plus, they automatically unsubscribe when your component unmounts.
 - **Access Firebase libraries from any component** - Need the Firestore SDK? `useFirestore`. Remote Config? `useRemoteConfig`.
 - **Safely configure Firebase libraries** - Libraries like Firestore and Remote Config require settings like `enablePersistence` to be set before any data fetches are made. This can be tough to support in React's world of re-renders. ReactFire gives you `useInitFirestore` and `useInitRemoteConfig` hooks that guarantee they're set before anything else.
+- **Optional `<Suspense>` support** - Hand loading states to React instead of checking a status yourself. Off by default, opt in with the `suspense` prop. See [Suspense](#suspense) below.
 
 ## Platform support
 
@@ -93,19 +94,16 @@ render(
 
 This repository is maintained by Googlers but is not a supported Firebase product. Issues here are answered by maintainers and other community members on GitHub on a best-effort basis.
 
-### Extra Experimental [concurrent mode](https://reactjs.org/docs/concurrent-mode-suspense.html) features
+## Suspense
 
-These features are marked as *extra experimental* because they use experimental React features that [will not be stable until sometime after React 18 is released](https://github.com/reactwg/react-18/discussions/47#:~:text=Likely%20after%20React%2018.0%3A%20Suspense%20for%20Data%20Fetching).
+ReactFire's hooks can throw promises for [`<Suspense>`](https://react.dev/reference/react/Suspense) to catch, so React handles loading states for you instead of you checking `status` on each result.
 
-- **Loading states handled by `<Suspense>`** - ReactFire's hooks throw promises
-  that Suspense can catch. Let React
-  [handle loading states for you](https://reactjs.org/docs/concurrent-mode-suspense.html).
-- **Automatically instrument your `Suspense` load times** - Need to automatically instrument your `Suspense` load times with [RUM](https://firebase.google.com/docs/perf-mon)? Use `<SuspenseWithPerf />`.
-
-Enable concurrent mode features by following the [concurrent mode setup guide](https://reactjs.org/docs/concurrent-mode-adoption.html#installation) and then setting the `suspense` prop in `FirebaseAppProvider`:
+This is **off by default**. Opt in with the `suspense` prop on `FirebaseAppProvider`:
 
 ```jsx
 <FirebaseAppProvider firebaseConfig={firebaseConfig} suspense={true}>
 ```
 
-See concurrent mode code samples in [example/withSuspense](https://github.com/FirebaseExtended/reactfire/tree/main/example/withSuspense)
+`<SuspenseWithPerf />` does the same and also instruments load times with [Performance Monitoring](https://firebase.google.com/docs/perf-mon).
+
+See [example/withSuspense](https://github.com/FirebaseExtended/reactfire/tree/main/example/withSuspense) for full samples.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,6 @@ This is **off by default**. Opt in with the `suspense` prop on `FirebaseAppProvi
 <FirebaseAppProvider firebaseConfig={firebaseConfig} suspense={true}>
 ```
 
-`<SuspenseWithPerf />` does the same and also instruments load times with [Performance Monitoring](https://firebase.google.com/docs/perf-mon).
+`<SuspenseWithPerf />` does the same and also measures how long the fallback was shown, using the browser's [User Timing API](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/User_timing).
 
 See [example/withSuspense](https://github.com/FirebaseExtended/reactfire/tree/main/example/withSuspense) for full samples.


### PR DESCRIPTION
Closes #756.

The "Extra Experimental concurrent mode features" section rests on a claim that is no longer true. It says these features "will not be stable until sometime after React 18 is released". React 18 shipped in 2022, and concurrent mode was abandoned as a concept rather than stabilised, so a reader today is told to follow a setup guide for a React feature that does not exist.

All three of its `reactjs.org/docs/concurrent-mode-*` links are dead pages. This PR removes all three from the README. One more survives in a comment in `example/index.tsx`, left for a separate follow-up so this stays docs-scoped.

## What changed

- Removed the "Extra Experimental concurrent mode features" heading and its stale premise paragraph.
- Added a `<Suspense>` bullet to **What is ReactFire?**, as the issue asked.
- Rehomed the remaining content as a plain `## Suspense` section.
- Added that suspense is **off by default**, which the old text never stated. Verified against `src/firebaseApp.tsx` (`suspense ?? false`, lines 57 and 66).
- Described what `<SuspenseWithPerf />` actually does. It measures with the browser User Timing API, not the Firebase Performance SDK. See below.

## What was kept, and why

The issue asks for the whole section to be removed. Two things were kept:

- the `suspense={true}` snippet, which is the only place the repo documents how to turn suspense on
- the `<SuspenseWithPerf />` mention, which was the only prose reference to that component anywhere outside the generated API report

The stale part was the "extra experimental / concurrent mode" framing and its dead links, not the usage documentation, so that framing is what this removes.

## The Performance Monitoring claim, corrected in review

The first revision carried the old text's claim that `<SuspenseWithPerf />` "instruments load times with Performance Monitoring", linking the Firebase perf-mon docs. Armando checked it against the source and it is wrong: `src/performance.tsx` uses only `performance.mark` / `performance.measure` from the browser's User Timing API, and still carries a `// TODO: Should this import firebase/performance?`. Nothing there touches the Firebase Performance SDK.

The claim is inherited rather than introduced here, but this PR rewrites that sentence anyway, so it is fixed rather than carried forward. The line now describes the User Timing behaviour and links MDN.

## Notes

- Docs-only. No source change, so no reference docs regeneration is needed.
- This section gets rewritten again at V5, when the suspend path moves to `use()`. It was kept minimal for that reason.
- If `Test Node.js 24` goes red here, it is very likely #776 rather than anything in this diff, given this PR touches only `README.md`.
