### PR TITLE
fix(ssr): add getServerSnapshot to useObservable's useSyncExternalStore

### DIFF
--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -109,15 +109,26 @@ export function useObservable<T = unknown>(observableId: string, source: Observa
   // required for server-rendered content" and the surrounding subtree falls back to
   // client rendering.
   //
+  // This applies on React 18 and up. Below that, `use-sync-external-store/shim` ignores the
+  // third argument on the server as well as the client, so both shapes render identically
+  // and nothing here regresses. It also does nothing for it.
+  //
   // This deliberately does NOT return `observable.immutableStatus` the way `getSnapshot`
   // does. `preloadedObservables` is a `globalThis` cache keyed only by `observableId`, so
   // on a server it is shared by every concurrent request. Seeding the server snapshot from
-  // it would let one request render data another request fetched for the same path. Only
-  // `config` is safe to read here, because it comes from the caller on this render.
+  // it would let one request render data another request fetched for the same path.
+  //
+  // So no field below carries data across requests: `status`, `hasEmitted` and `data` come
+  // from `config`, which is the caller's own input on this render. `firstValuePromise` does
+  // read the shared `observable`, but it is a `Promise<void>` that resolves without a value,
+  // so it discloses nothing. It is not optional on `ObservableStatus`, and the
+  // `as ObservableStatus<T>` cast below means neither `tsc` nor the tests would notice if it
+  // were dropped: a caller doing `status.firstValuePromise.then(...)` on the server would
+  // just throw.
   //
   // The result is memoized per component instance because React compares the value it
   // returns across renders, and a fresh object each time is what triggers the
-  // "The result of getSnapshot should be cached" error.
+  // "The result of getServerSnapshot should be cached" error.
   const serverSnapshotRef = React.useRef<ObservableStatus<T> | undefined>(undefined);
   const getServerSnapshot = React.useCallback<() => ObservableStatus<T>>(() => {
     if (serverSnapshotRef.current === undefined) {

--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -107,7 +107,8 @@ export function useObservable<T = unknown>(observableId: string, source: Observa
   // Reads only `config`, never `observable.immutableStatus`: `preloadedObservables` is a
   // `globalThis` cache keyed only by `observableId`, so a server shares it across concurrent
   // requests, and seeding from it would render one request's data into another's HTML.
-  // The `as` cast below hides a missing `firstValuePromise` from `tsc` and the tests.
+  // React 18 and up only: below that the shim's server path ignores this function and returns
+  // `getSnapshot()`, so the cached value still reaches the markup there.
   // Held in a ref because React requires a stable value across renders.
   const serverSnapshotRef = React.useRef<ObservableStatus<T> | undefined>(undefined);
   const getServerSnapshot = React.useCallback<() => ObservableStatus<T>>(() => {
@@ -121,7 +122,7 @@ export function useObservable<T = unknown>(observableId: string, source: Observa
         data: initialDataValue,
         error: undefined,
         firstValuePromise: observable.firstEmission
-      } as ObservableStatus<T>;
+      };
     }
 
     return serverSnapshotRef.current;

--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -104,7 +104,44 @@ export function useObservable<T = unknown>(observableId: string, source: Observa
     return observable.immutableStatus;
   }, [observable]);
 
-  const update = useSyncExternalStore(subscribe, getSnapshot);
+  // `useSyncExternalStore` requires a third argument when the tree is rendered on a
+  // server or hydrated; without it React throws "Missing getServerSnapshot, which is
+  // required for server-rendered content" and the surrounding subtree falls back to
+  // client rendering.
+  //
+  // This deliberately does NOT return `observable.immutableStatus` the way `getSnapshot`
+  // does. `preloadedObservables` is a `globalThis` cache keyed only by `observableId`, so
+  // on a server it is shared by every concurrent request. Seeding the server snapshot from
+  // it would let one request render data another request fetched for the same path. Only
+  // `config` is safe to read here, because it comes from the caller on this render.
+  //
+  // The result is memoized per component instance because React compares the value it
+  // returns across renders, and a fresh object each time is what triggers the
+  // "The result of getSnapshot should be cached" error.
+  const serverSnapshotRef = React.useRef<ObservableStatus<T> | undefined>(undefined);
+  const getServerSnapshot = React.useCallback<() => ObservableStatus<T>>(() => {
+    if (serverSnapshotRef.current === undefined) {
+      const initialDataValue = config?.initialData ?? config?.startWithValue;
+
+      serverSnapshotRef.current = {
+        status: hasInitialData ? 'success' : 'loading',
+        hasEmitted: hasInitialData,
+        isComplete: false,
+        data: initialDataValue,
+        error: undefined,
+        firstValuePromise: observable.firstEmission
+      } as ObservableStatus<T>;
+    }
+
+    return serverSnapshotRef.current;
+    // `config.initialData` and `config.startWithValue` are read above but deliberately left
+    // out of the dependency array. Callers routinely pass a fresh `config` literal on every
+    // render, so including them would rebuild this callback constantly, and the ref means
+    // the value is computed once per component instance regardless.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [observable, hasInitialData]);
+
+  const update = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   // Return a new object with initialData overlaid rather than mutating the shared
   // _immutableStatus reference, which is the same object across all components

--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -104,31 +104,11 @@ export function useObservable<T = unknown>(observableId: string, source: Observa
     return observable.immutableStatus;
   }, [observable]);
 
-  // `useSyncExternalStore` requires a third argument when the tree is rendered on a
-  // server or hydrated; without it React throws "Missing getServerSnapshot, which is
-  // required for server-rendered content" and the surrounding subtree falls back to
-  // client rendering.
-  //
-  // This applies on React 18 and up. Below that, `use-sync-external-store/shim` ignores the
-  // third argument on the server as well as the client, so both shapes render identically
-  // and nothing here regresses. It also does nothing for it.
-  //
-  // This deliberately does NOT return `observable.immutableStatus` the way `getSnapshot`
-  // does. `preloadedObservables` is a `globalThis` cache keyed only by `observableId`, so
-  // on a server it is shared by every concurrent request. Seeding the server snapshot from
-  // it would let one request render data another request fetched for the same path.
-  //
-  // So no field below carries data across requests: `status`, `hasEmitted` and `data` come
-  // from `config`, which is the caller's own input on this render. `firstValuePromise` does
-  // read the shared `observable`, but it is a `Promise<void>` that resolves without a value,
-  // so it discloses nothing. It is not optional on `ObservableStatus`, and the
-  // `as ObservableStatus<T>` cast below means neither `tsc` nor the tests would notice if it
-  // were dropped: a caller doing `status.firstValuePromise.then(...)` on the server would
-  // just throw.
-  //
-  // The result is memoized per component instance because React compares the value it
-  // returns across renders, and a fresh object each time is what triggers the
-  // "The result of getServerSnapshot should be cached" error.
+  // Reads only `config`, never `observable.immutableStatus`: `preloadedObservables` is a
+  // `globalThis` cache keyed only by `observableId`, so a server shares it across concurrent
+  // requests, and seeding from it would render one request's data into another's HTML.
+  // The `as` cast below hides a missing `firstValuePromise` from `tsc` and the tests.
+  // Held in a ref because React requires a stable value across renders.
   const serverSnapshotRef = React.useRef<ObservableStatus<T> | undefined>(undefined);
   const getServerSnapshot = React.useCallback<() => ObservableStatus<T>>(() => {
     if (serverSnapshotRef.current === undefined) {
@@ -145,10 +125,8 @@ export function useObservable<T = unknown>(observableId: string, source: Observa
     }
 
     return serverSnapshotRef.current;
-    // `config.initialData` and `config.startWithValue` are read above but deliberately left
-    // out of the dependency array. Callers routinely pass a fresh `config` literal on every
-    // render, so including them would rebuild this callback constantly, and the ref means
-    // the value is computed once per component instance regardless.
+    // Callers pass a fresh `config` literal each render, so the fields read above are kept
+    // out of the deps; the ref computes the value once per instance anyway.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [observable, hasInitialData]);
 

--- a/test/useObservable.test.tsx
+++ b/test/useObservable.test.tsx
@@ -366,8 +366,8 @@ describe('useObservable', () => {
         sink.on('error', reject);
 
         const stream = renderToPipeableStream(<Probe observableId="ssr-streaming" observable$={observable$} />, {
-          onError(e) {
-            error = e;
+          onError(caughtError) {
+            error = caughtError;
           },
           onAllReady() {
             stream.pipe(sink);

--- a/test/useObservable.test.tsx
+++ b/test/useObservable.test.tsx
@@ -446,5 +446,23 @@ describe('useObservable', () => {
       expect(html).not.toContain('first-request-secret');
       expect(html).toContain('loading:undefined');
     });
+
+    it('prefers the callers initialData over a value already in the shared cache', async () => {
+      // The branch above that reads `initialData` is only reachable when the cache ALREADY
+      // holds a value for this id: otherwise the overlay in `useObservable` sets status,
+      // data and hasEmitted itself and the server snapshot never decides anything. So seed
+      // the cache first, exactly as the leak test does, and only then pass `initialData`.
+      const observable$: Subject<any> = new Subject();
+      const observableId = 'ssr-initial-data-beats-cache';
+
+      const { result } = renderHook(() => useObservable(observableId, observable$, { suspense: false }));
+      act(() => observable$.next('another-requests-value'));
+      await waitFor(() => expect(result.current.data).toEqual('another-requests-value'));
+
+      const html = renderToString(<Probe observableId={observableId} observable$={observable$} config={{ initialData: 'my-own-data' }} />);
+
+      expect(html).toContain('success:my-own-data');
+      expect(html).not.toContain('another-requests-value');
+    });
   });
 });

--- a/test/useObservable.test.tsx
+++ b/test/useObservable.test.tsx
@@ -1,8 +1,9 @@
 import '@testing-library/jest-dom/extend-expect';
 import { act, cleanup, render, renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
+import { renderToString } from 'react-dom/server';
 import { of, Subject, BehaviorSubject, throwError } from 'rxjs';
-import { useObservable } from '../src/index';
+import { useObservable, ReactFireOptions } from '../src/index';
 
 describe('useObservable', () => {
   afterEach(cleanup);
@@ -327,6 +328,61 @@ describe('useObservable', () => {
 
       // if useObservable doesn't re-emit, the value here will still be "Jeff"
       expect(refreshedComp).toHaveTextContent('James');
+    });
+  });
+
+  describe('Server rendering', () => {
+    // Renders `status` and `data` so the assertions read the snapshot React actually used,
+    // rather than a value the test computed for itself.
+    const Probe = ({ observableId, observable$, config }: { observableId: string; observable$: Subject<any>; config?: ReactFireOptions }) => {
+      const { status, data } = useObservable(observableId, observable$, { suspense: false, ...config });
+      // A single interpolated child, because adjacent JSX text nodes render with `<!-- -->`
+      // separators between them and the assertions below match on the plain string.
+      return <div>{`${status}:${String(data)}`}</div>;
+    };
+
+    it('renders on the server instead of throwing', () => {
+      const observable$: Subject<any> = new Subject();
+
+      // Without a getServerSnapshot, React throws "Missing getServerSnapshot, which is
+      // required for server-rendered content" and the whole subtree falls back to client
+      // rendering. This is the #748 regression test: delete the third argument to
+      // useSyncExternalStore and this assertion fails.
+      expect(() => renderToString(<Probe observableId="ssr-renders" observable$={observable$} />)).not.toThrow();
+    });
+
+    it('reports loading on the server when there is no initialData', () => {
+      const observable$: Subject<any> = new Subject();
+
+      const html = renderToString(<Probe observableId="ssr-loading" observable$={observable$} />);
+
+      expect(html).toContain('loading:undefined');
+    });
+
+    it('reports initialData on the server when it is provided', () => {
+      const observable$: Subject<any> = new Subject();
+
+      const html = renderToString(<Probe observableId="ssr-initial-data" observable$={observable$} config={{ initialData: 'seeded' }} />);
+
+      expect(html).toContain('success:seeded');
+    });
+
+    it('does not leak a cached value from another request into the server snapshot', async () => {
+      // `preloadedObservables` lives on `globalThis` and is keyed only by observableId, so on
+      // a server every concurrent request shares it. A getServerSnapshot that read
+      // `observable.immutableStatus` would render whatever the previous request left behind.
+      // Here the first render stands in for that earlier request.
+      const observable$: Subject<any> = new Subject();
+      const observableId = 'ssr-no-cross-request-leak';
+
+      const { result } = renderHook(() => useObservable(observableId, observable$, { suspense: false }));
+      act(() => observable$.next('first-request-secret'));
+      await waitFor(() => expect(result.current.data).toEqual('first-request-secret'));
+
+      const html = renderToString(<Probe observableId={observableId} observable$={observable$} />);
+
+      expect(html).not.toContain('first-request-secret');
+      expect(html).toContain('loading:undefined');
     });
   });
 });

--- a/test/useObservable.test.tsx
+++ b/test/useObservable.test.tsx
@@ -332,22 +332,18 @@ describe('useObservable', () => {
   });
 
   describe('Server rendering', () => {
-    // Renders `status` and `data` so the assertions read the snapshot React actually used,
-    // rather than a value the test computed for itself.
+    // Renders `status` and `data` so assertions read the snapshot React actually used.
     const Probe = ({ observableId, observable$, config }: { observableId: string; observable$: Subject<any>; config?: ReactFireOptions }) => {
       const { status, data } = useObservable(observableId, observable$, { suspense: false, ...config });
-      // A single interpolated child, because adjacent JSX text nodes render with `<!-- -->`
-      // separators between them and the assertions below match on the plain string.
+      // One interpolated child: adjacent JSX text nodes render with `<!-- -->` between them.
       return <div>{`${status}:${String(data)}`}</div>;
     };
 
     it('renders on the server instead of throwing', () => {
       const observable$: Subject<any> = new Subject();
 
-      // Without a getServerSnapshot, React throws "Missing getServerSnapshot, which is
-      // required for server-rendered content" and the whole subtree falls back to client
-      // rendering. This is the #748 regression test: delete the third argument to
-      // useSyncExternalStore and this assertion fails.
+      // The #748 regression test: delete the third argument to useSyncExternalStore and
+      // this fails with "Missing getServerSnapshot".
       expect(() => renderToString(<Probe observableId="ssr-renders" observable$={observable$} />)).not.toThrow();
     });
 
@@ -368,10 +364,8 @@ describe('useObservable', () => {
     });
 
     it('does not leak a cached value from another request into the server snapshot', async () => {
-      // `preloadedObservables` lives on `globalThis` and is keyed only by observableId, so on
-      // a server every concurrent request shares it. A getServerSnapshot that read
-      // `observable.immutableStatus` would render whatever the previous request left behind.
-      // Here the first render stands in for that earlier request.
+      // `preloadedObservables` is on `globalThis`, keyed only by observableId, so concurrent
+      // server requests share it. The first render below stands in for an earlier request.
       const observable$: Subject<any> = new Subject();
       const observableId = 'ssr-no-cross-request-leak';
 
@@ -386,10 +380,8 @@ describe('useObservable', () => {
     });
 
     it('prefers the callers initialData over a value already in the shared cache', async () => {
-      // The branch above that reads `initialData` is only reachable when the cache ALREADY
-      // holds a value for this id: otherwise the overlay in `useObservable` sets status,
-      // data and hasEmitted itself and the server snapshot never decides anything. So seed
-      // the cache first, exactly as the leak test does, and only then pass `initialData`.
+      // The `initialData` branch is only reachable when the cache already holds a value for
+      // this id; otherwise `useObservable`'s overlay decides and the snapshot never does.
       const observable$: Subject<any> = new Subject();
       const observableId = 'ssr-initial-data-beats-cache';
 

--- a/test/useObservable.test.tsx
+++ b/test/useObservable.test.tsx
@@ -384,5 +384,23 @@ describe('useObservable', () => {
       expect(html).not.toContain('first-request-secret');
       expect(html).toContain('loading:undefined');
     });
+
+    it('prefers the callers initialData over a value already in the shared cache', async () => {
+      // The branch above that reads `initialData` is only reachable when the cache ALREADY
+      // holds a value for this id: otherwise the overlay in `useObservable` sets status,
+      // data and hasEmitted itself and the server snapshot never decides anything. So seed
+      // the cache first, exactly as the leak test does, and only then pass `initialData`.
+      const observable$: Subject<any> = new Subject();
+      const observableId = 'ssr-initial-data-beats-cache';
+
+      const { result } = renderHook(() => useObservable(observableId, observable$, { suspense: false }));
+      act(() => observable$.next('another-requests-value'));
+      await waitFor(() => expect(result.current.data).toEqual('another-requests-value'));
+
+      const html = renderToString(<Probe observableId={observableId} observable$={observable$} config={{ initialData: 'my-own-data' }} />);
+
+      expect(html).toContain('success:my-own-data');
+      expect(html).not.toContain('another-requests-value');
+    });
   });
 });

--- a/test/useObservable.test.tsx
+++ b/test/useObservable.test.tsx
@@ -1,8 +1,9 @@
 import '@testing-library/jest-dom/extend-expect';
 import { act, cleanup, render, renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
+import { renderToString } from 'react-dom/server';
 import { of, Subject, BehaviorSubject, throwError } from 'rxjs';
-import { useObservable, FirebaseAppProvider } from '../src/index';
+import { useObservable, FirebaseAppProvider, ReactFireOptions } from '../src/index';
 import { initializeApp } from 'firebase/app';
 import { baseConfig } from './appConfig';
 
@@ -389,6 +390,61 @@ describe('useObservable', () => {
 
       spy.mockRestore();
       window.removeEventListener('error', onError);
+    });
+  });
+
+  describe('Server rendering', () => {
+    // Renders `status` and `data` so the assertions read the snapshot React actually used,
+    // rather than a value the test computed for itself.
+    const Probe = ({ observableId, observable$, config }: { observableId: string; observable$: Subject<any>; config?: ReactFireOptions }) => {
+      const { status, data } = useObservable(observableId, observable$, { suspense: false, ...config });
+      // A single interpolated child, because adjacent JSX text nodes render with `<!-- -->`
+      // separators between them and the assertions below match on the plain string.
+      return <div>{`${status}:${String(data)}`}</div>;
+    };
+
+    it('renders on the server instead of throwing', () => {
+      const observable$: Subject<any> = new Subject();
+
+      // Without a getServerSnapshot, React throws "Missing getServerSnapshot, which is
+      // required for server-rendered content" and the whole subtree falls back to client
+      // rendering. This is the #748 regression test: delete the third argument to
+      // useSyncExternalStore and this assertion fails.
+      expect(() => renderToString(<Probe observableId="ssr-renders" observable$={observable$} />)).not.toThrow();
+    });
+
+    it('reports loading on the server when there is no initialData', () => {
+      const observable$: Subject<any> = new Subject();
+
+      const html = renderToString(<Probe observableId="ssr-loading" observable$={observable$} />);
+
+      expect(html).toContain('loading:undefined');
+    });
+
+    it('reports initialData on the server when it is provided', () => {
+      const observable$: Subject<any> = new Subject();
+
+      const html = renderToString(<Probe observableId="ssr-initial-data" observable$={observable$} config={{ initialData: 'seeded' }} />);
+
+      expect(html).toContain('success:seeded');
+    });
+
+    it('does not leak a cached value from another request into the server snapshot', async () => {
+      // `preloadedObservables` lives on `globalThis` and is keyed only by observableId, so on
+      // a server every concurrent request shares it. A getServerSnapshot that read
+      // `observable.immutableStatus` would render whatever the previous request left behind.
+      // Here the first render stands in for that earlier request.
+      const observable$: Subject<any> = new Subject();
+      const observableId = 'ssr-no-cross-request-leak';
+
+      const { result } = renderHook(() => useObservable(observableId, observable$, { suspense: false }));
+      act(() => observable$.next('first-request-secret'));
+      await waitFor(() => expect(result.current.data).toEqual('first-request-secret'));
+
+      const html = renderToString(<Probe observableId={observableId} observable$={observable$} />);
+
+      expect(html).not.toContain('first-request-secret');
+      expect(html).toContain('loading:undefined');
     });
   });
 });

--- a/test/useObservable.test.tsx
+++ b/test/useObservable.test.tsx
@@ -1,7 +1,8 @@
 import '@testing-library/jest-dom/extend-expect';
 import { act, cleanup, render, renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
-import { renderToString } from 'react-dom/server';
+import { Writable } from 'node:stream';
+import { renderToString, renderToPipeableStream } from 'react-dom/server';
 import { of, Subject, BehaviorSubject, throwError } from 'rxjs';
 import { useObservable, ReactFireOptions } from '../src/index';
 
@@ -345,6 +346,37 @@ describe('useObservable', () => {
       // The #748 regression test: delete the third argument to useSyncExternalStore and
       // this fails with "Missing getServerSnapshot".
       expect(() => renderToString(<Probe observableId="ssr-renders" observable$={observable$} />)).not.toThrow();
+    });
+
+    // The App Router streams rather than calling renderToString, and streaming surfaces
+    // failures the synchronous renderer does not, so the fix is checked against both.
+    it('renders on the server under the streaming renderer', async () => {
+      const observable$: Subject<any> = new Subject();
+      let error: unknown;
+
+      const html = await new Promise<string>((resolve, reject) => {
+        const chunks: string[] = [];
+        const sink = new Writable({
+          write(chunk, _encoding, callback) {
+            chunks.push(chunk.toString());
+            callback();
+          }
+        });
+        sink.on('finish', () => resolve(chunks.join('')));
+        sink.on('error', reject);
+
+        const stream = renderToPipeableStream(<Probe observableId="ssr-streaming" observable$={observable$} />, {
+          onError(e) {
+            error = e;
+          },
+          onAllReady() {
+            stream.pipe(sink);
+          }
+        });
+      });
+
+      expect(error).toBeUndefined();
+      expect(html).toContain('loading:undefined');
     });
 
     it('reports loading on the server when there is no initialData', () => {


### PR DESCRIPTION
Fixes #748.

`useObservable` called `useSyncExternalStore` with two arguments. React requires a third, `getServerSnapshot`, whenever the tree is server rendered or hydrated. Without it React throws `Missing getServerSnapshot, which is required for server-rendered content` and the surrounding subtree silently falls back to client rendering, which is why a Next.js App Router page using any reactfire hook loses SSR for that subtree.

## The part worth reviewing

The issue proposes returning "the same seeded `immutableStatus` the client snapshot returns". **That version is unsafe and this PR deliberately does not do it.**

`preloadedObservables` is a `Map` on `globalThis`, keyed only by `observableId`. In a browser that is one user's cache. On a server it is shared by every concurrent request, so a `getServerSnapshot` that read `observable.immutableStatus` would render data request A fetched into request B's HTML whenever both touch the same path.

That leak is unreachable today only because SSR throws before it can happen. So fixing the crash the obvious way would trade a crash for a cross-request data disclosure, which is the worse of the two.

This implementation reads **only `config`** for anything data-bearing, and `config` arrives from the caller on the current render, so it is per-request. With `initialData` it reports `success` and that value; without it, `loading`. (`firstValuePromise` does read the shared observable, but it is a `Promise<void>` that resolves without a value, so nothing crosses through it.) The result is held in a ref so the value is stable across renders, which is what React's "The result of getServerSnapshot should be cached" check wants.

## Verification

Six tests under a new `Server rendering` block, and both mutations were run rather than assumed:

- **Drop the third argument:** all six fail, with React's own `Missing getServerSnapshot` error. So the tests are load-bearing rather than decorative.
- **Return `observable.immutableStatus` instead** (the straightforward implementation): **4 of 6 pass and 2 fail**, `does not leak a cached value from another request into the server snapshot` and `prefers the callers initialData over a value already in the shared cache`. Those two are the tests that earn their place, and they are why the constraint above is written down in the code rather than left to reviewer memory.

`tsc` passes on both `tsconfig.json` and `tsconfig.test.json`; `useObservable` is 20/20; eslint reports 0 errors on both changed files.

## Scope: this does not make SSR work, and the title should not be read that way

**In non-suspense mode without `initialData`, a server render produces `loading` placeholders**, not data. That is inherent to the model rather than a gap in it, for the reason above: `observableId` alone cannot distinguish this request's data from another request's. Real server-side data needs per-request cache scoping, which is a separate piece of work.

**Suspense mode reaches `getServerSnapshot` too, and its server behavior does change.** The suspend decision is `hasData = observable.hasValue || hasInitialData`, so whenever the shared cache already holds a value for the id, the guard at `src/useObservable.ts:80` is skipped and the hook runs. A `SuspenseSubject` subscribes in its constructor, so even a first render that crashes seeds that entry: on a long-lived server process the already-cached case is the steady state, not an edge.

Measured with the same probe on both branches:

| `suspense: true` | `main` | this branch |
| --- | --- | --- |
| Cold cache, `renderToString` | `A component suspended while responding to synchronous input` | same |
| Cold cache, streaming | hangs, no completion | same |
| **Value cached for the id**, `renderToString` | `Missing getServerSnapshot` | renders `loading:undefined` |
| **Value cached for the id**, streaming | `onShellError`, empty output | completes with `loading:undefined` |
| Value cached, consumer dereferences `data` | `Missing getServerSnapshot` | `TypeError: Cannot read properties of undefined` |

**The cost is diagnosability.** A named library error becomes silent `loading` HTML, or a `TypeError` inside the consumer's own component, since suspense mode's contract is that the hook does not return until data exists and callers dereference accordingly. Not fixed here and not fixable without per-request scoping, but worth stating rather than leaving as "suspense mode cannot server-render".

## Notes

- **The `use-sync-external-store/shim` is a red herring for React 18 and 19.** Its own implementation ignores `getServerSnapshot` on purpose, but it resolves to `React.useSyncExternalStore` whenever React exposes it, so the third argument reaches React's real implementation. Reading only the shim would suggest this fix cannot work. **On 16 and 17, which the peer range still allows, it does not:** the shim's server path returns `getSnapshot()`, so the cached value reaches the markup there. Unchanged from `main` and out of scope here, and the source comment is scoped accordingly.
- **No reference docs regeneration**, since no exported symbol changed.
- The `globalThis` cache itself is unfixed. This PR contains the hazard at the one place it would otherwise become reachable, and nowhere else.
- The server snapshot literal carries no `as` cast, so `tsc` fails with TS2741 if a required field such as `firstValuePromise` goes missing.
- One `eslint-disable` for `react-hooks/exhaustive-deps`, with the reason in a comment above it: callers routinely pass a fresh `config` literal each render, and the ref means the value is computed once per component instance anyway.
