### PR TITLE
ci: add a manual firestore flake probe for #776

### DIFF
--- a/.github/workflows/flake-probe.yaml
+++ b/.github/workflows/flake-probe.yaml
@@ -6,6 +6,10 @@
 # not the same bug. This runs both `@grpc/grpc-js` arms on both Node versions under CI
 # conditions so the comparison is made where the failure actually happens.
 #
+# Both arms run inside a single job, sequentially on the same runner. They are
+# deliberately NOT a matrix dimension: the whole premise is that the machine matters,
+# so splitting the arms across two runners would reintroduce the variable being tested.
+#
 # Manual only. It never runs on a push, a PR or a schedule, so it costs nothing until
 # someone asks for it.
 name: Firestore flake probe
@@ -16,7 +20,7 @@ on:
       iterations:
         description: "Test runs per arm (each is a full emulator start/stop, roughly 25s)"
         required: false
-        default: "20"
+        default: "30"
       node_versions:
         description: "JSON array of Node majors to probe"
         required: false
@@ -37,9 +41,8 @@ jobs:
     strategy:
       matrix:
         node: ${{ fromJSON(inputs.node_versions) }}
-        arm: ${{ fromJSON(inputs.arms) }}
       fail-fast: false
-    name: Probe Node ${{ matrix.node }} / ${{ matrix.arm }}
+    name: Probe Node ${{ matrix.node }}
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -68,32 +71,16 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      # `npm pkg set` mangles keys containing a slash, so edit package.json directly.
-      # `npm install` (not `npm ci`) is required here because applying an override
-      # necessarily changes the lockfile.
-      - name: Apply the grpc-js override
-        if: ${{ matrix.arm == 'override' }}
-        run: |
-          node -e '
-            const fs = require("fs");
-            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
-            pkg.overrides = { ...pkg.overrides, "@grpc/grpc-js": "^1.14.0" };
-            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
-          '
-          npm install --no-audit --no-fund
-
-      - name: Record the resolved grpc-js version
-        run: |
-          RESOLVED="$(node -p "require('@grpc/grpc-js/package.json').version")"
-          echo "resolved_grpc=$RESOLVED" >> "$GITHUB_ENV"
-          echo "Resolved @grpc/grpc-js: $RESOLVED"
-
       # Inputs and matrix values are passed through `env` rather than interpolated into
       # the script body, so nothing from the dispatch form can be executed as shell.
+      #
+      # Counts are appended to `probe-counts.tsv` as each arm finishes, and the summary
+      # is rendered by a separate `always()` step. If the job hits its timeout partway
+      # through, whatever was measured before the wall still gets reported.
       - name: Run the probe
         env:
           ITERATIONS: ${{ inputs.iterations }}
-          ARM: ${{ matrix.arm }}
+          ARMS: ${{ inputs.arms }}
           NODE_MAJOR: ${{ matrix.node }}
         run: |
           set -uo pipefail
@@ -107,73 +94,177 @@ jobs:
             exit 1
           fi
 
-          pass=0
-          flake=0
-          infra=0
-          grpc_err=0
+          # Validate the arm list rather than trusting the dispatch form, and normalize
+          # it to a space-separated list. Order is forced baseline-then-override because
+          # applying the override mutates node_modules for everything after it.
+          ARM_LIST="$(node -e '
+            const arms = JSON.parse(process.env.ARMS);
+            if (!Array.isArray(arms) || arms.length === 0) throw new Error("arms must be a non-empty JSON array");
+            const allowed = ["baseline", "override"];
+            for (const a of arms) if (!allowed.includes(a)) throw new Error("unknown arm: " + a);
+            process.stdout.write(allowed.filter((a) => arms.includes(a)).join(" "));
+          ')" || exit 1
+
           mkdir -p probe-logs
+          : > probe-counts.tsv
+          : > probe-unmatched.txt
 
-          for i in $(seq 1 "$ITERATIONS"); do
-            log="probe-logs/run-$i.log"
+          for arm in $ARM_LIST; do
+            echo "::group::Arm: $arm"
 
-            # A fresh emulator per iteration, matching how `npm test` runs in CI. Reusing
-            # one emulator across iterations would measure a different thing.
-            set +e
-            npx firebase emulators:exec --only firestore --project=rxfire-525a3 \
-              "npx vitest run firestore" > "$log" 2>&1
-            rc=$?
-            set -e
-
-            if grep -q "RESOURCE_EXHAUSTED: Received message larger than max" "$log"; then
-              grpc_err=$((grpc_err + 1))
+            # `npm pkg set` mangles keys containing a slash, so edit package.json directly.
+            # `npm install` (not `npm ci`) is required here because applying an override
+            # necessarily changes the lockfile.
+            if [ "$arm" = "override" ]; then
+              node -e '
+                const fs = require("fs");
+                const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+                pkg.overrides = { ...pkg.overrides, "@grpc/grpc-js": "^1.14.0" };
+                fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+              '
+              npm install --no-audit --no-fund
             fi
 
-            if [ "$rc" -eq 0 ]; then
-              pass=$((pass + 1))
-              echo "run $i: PASS"
-            elif grep -q "expected 'loading' to deeply equal 'success'" "$log"; then
-              # The #776 signature specifically, rather than "the job went red".
-              flake=$((flake + 1))
-              echo "run $i: FLAKE (rc=$rc)"
-            else
-              # Emulator start failures and the like. Counted separately because folding
-              # them in previously inflated a local flake-rate estimate by ~50%.
-              infra=$((infra + 1))
-              echo "run $i: INFRA FAILURE (rc=$rc), excluded from the rate"
-              tail -20 "$log"
-            fi
+            resolved="$(node -p "require('@grpc/grpc-js/package.json').version")"
+            echo "Arm $arm resolved @grpc/grpc-js: $resolved"
+
+            pass=0
+            flake=0
+            infra=0
+            hang=0
+            grpc_err=0
+            flake_with_grpc=0
+
+            for i in $(seq 1 "$ITERATIONS"); do
+              log="probe-logs/$arm-run-$i.log"
+
+              # A fresh emulator per iteration, matching how `npm test` runs in CI. Reusing
+              # one emulator across iterations would measure a different thing.
+              npx firebase emulators:exec --only firestore --project=rxfire-525a3 \
+                "npx vitest run firestore" > "$log" 2>&1
+              rc=$?
+
+              saw_grpc=0
+              if grep -q "RESOURCE_EXHAUSTED: Received message larger than max" "$log"; then
+                grpc_err=$((grpc_err + 1))
+                saw_grpc=1
+              fi
+
+              if [ "$rc" -eq 0 ]; then
+                pass=$((pass + 1))
+                echo "run $i: PASS"
+              elif grep -q "expected 'loading' to deeply equal 'success'" "$log"; then
+                # The #776 signature specifically, rather than "the job went red".
+                flake=$((flake + 1))
+                # Whether the gRPC desync and the #776 assertion co-occur is the whole
+                # question, so count the overlap rather than two independent totals.
+                if [ "$saw_grpc" -eq 1 ]; then
+                  flake_with_grpc=$((flake_with_grpc + 1))
+                fi
+                echo "run $i: FLAKE (rc=$rc)"
+              elif grep -qE "Test timed out in [0-9]+ms|Hook timed out in [0-9]+ms" "$log"; then
+                # #776 also reports a ~120s hang. A hang produces no assertion line, so
+                # without this bucket it would land in `infra` and vanish from the rate.
+                hang=$((hang + 1))
+                echo "run $i: HANG (rc=$rc)"
+              else
+                # Emulator start failures and the like. Counted separately because folding
+                # them in previously inflated a local flake-rate estimate by ~50%.
+                infra=$((infra + 1))
+                echo "run $i: INFRA FAILURE (rc=$rc), excluded from the rate"
+                # The flake match is a literal vitest assertion string. If vitest ever
+                # rewords it, every real flake would quietly become an infra failure, so
+                # surface the assertion line of anything unrecognized instead of hiding it.
+                if line="$(grep -m1 -E "AssertionError|expected .* to " "$log")"; then
+                  printf '%s run %s: %s\n' "$arm" "$i" "$line" >> probe-unmatched.txt
+                fi
+                tail -20 "$log"
+              fi
+            done
+
+            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+              "$NODE_MAJOR" "$arm" "$resolved" \
+              "$pass" "$flake" "$infra" "$hang" "$grpc_err" "$flake_with_grpc" \
+              >> probe-counts.tsv
+
+            echo "arm=$arm node=$NODE_MAJOR pass=$pass flake=$flake infra=$infra hang=$hang grpc_err=$grpc_err overlap=$flake_with_grpc"
+            echo "::endgroup::"
           done
 
-          counted=$((pass + flake))
-          if [ "$counted" -gt 0 ]; then
-            rate="$(node -e "process.stdout.write(((${flake}/${counted})*100).toFixed(1))")"
-          else
-            rate="n/a"
+      # Rendered separately, and on `always()`, so a job killed by `timeout-minutes`
+      # still reports every arm that finished before the wall.
+      - name: Summarize
+        if: ${{ always() }}
+        env:
+          NODE_MAJOR: ${{ matrix.node }}
+        run: |
+          set -uo pipefail
+
+          if [ ! -s probe-counts.tsv ]; then
+            echo "No arm completed; nothing to summarize." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
-          {
-            echo "### Node ${NODE_MAJOR} / ${ARM} (@grpc/grpc-js ${resolved_grpc})"
-            echo ""
-            echo "| Outcome | Count |"
-            echo "| --- | --- |"
-            echo "| Pass | ${pass} |"
-            echo "| Flake (#776 signature) | ${flake} |"
-            echo "| Infra failure (excluded) | ${infra} |"
-            echo "| Runs showing RESOURCE_EXHAUSTED | ${grpc_err} |"
-            echo ""
-            echo "**Flake rate: ${rate}% of ${counted} counted runs.**"
-            echo ""
-            if [ "$infra" -gt 0 ]; then
-              echo "> ${infra} run(s) failed for reasons other than the #776 assertion and are excluded from the rate."
-              echo ""
+          while IFS=$'\t' read -r node arm resolved pass flake infra hang grpc_err overlap; do
+            counted=$((pass + flake))
+            if [ "$counted" -gt 0 ]; then
+              # `< /dev/null` so the subshell cannot consume the loop's stdin.
+              rate="$(node -e "process.stdout.write(((${flake}/${counted})*100).toFixed(1))" < /dev/null)"
+            else
+              rate="n/a"
             fi
+
+            {
+              echo "### Node ${node} / ${arm} (@grpc/grpc-js ${resolved})"
+              echo ""
+              echo "| Outcome | Count |"
+              echo "| --- | --- |"
+              echo "| Pass | ${pass} |"
+              echo "| Flake (#776 signature) | ${flake} |"
+              echo "| ...of which also showed RESOURCE_EXHAUSTED | ${overlap} |"
+              echo "| Hang (test timeout, no assertion) | ${hang} |"
+              echo "| Infra failure (excluded) | ${infra} |"
+              echo "| Runs showing RESOURCE_EXHAUSTED | ${grpc_err} |"
+              echo ""
+              echo "**Flake rate: ${rate}% of ${counted} counted runs.**"
+              echo ""
+              if [ "$hang" -gt 0 ] || [ "$infra" -gt 0 ]; then
+                echo "> ${hang} hang(s) and ${infra} infra failure(s) are excluded from the rate."
+                echo ""
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+          done < probe-counts.tsv
+
+          {
+            echo "---"
+            echo ""
+            echo "**A clean table here is not a verdict on CI.** This probe runs one emulator"
+            echo "and one test file; \`npm run test\` in CI starts five emulators and runs the"
+            echo "whole suite with parallel workers. \`RESOURCE_EXHAUSTED\` has never appeared in"
+            echo "a firestore-only run, so this configuration may reproduce the local failure"
+            echo "while never reaching the CI one."
+            echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "arm=${ARM} node=${NODE_MAJOR} pass=${pass} flake=${flake} infra=${infra} grpc_err=${grpc_err} rate=${rate}%"
+          if [ -s probe-unmatched.txt ]; then
+            {
+              echo "### ⚠️ Unrecognized failures"
+              echo ""
+              echo "These runs failed with an assertion the classifier does not know, so they"
+              echo "were counted as infra. If vitest reworded the #776 message, the flake counts"
+              echo "above are wrong and the pattern needs updating."
+              echo ""
+              echo '```'
+              cat probe-unmatched.txt
+              echo '```'
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           # The probe reports; it does not fail. A red job here would mean the probe
           # broke, not that the flake reproduced.
-          if [ "$counted" -eq 0 ]; then
+          total_counted="$(awk -F'\t' '{ s += $4 + $5 } END { print s + 0 }' probe-counts.tsv)"
+          if [ "$total_counted" -eq 0 ]; then
             echo "Every run failed for infrastructure reasons; the probe measured nothing."
             exit 1
           fi
@@ -182,6 +273,9 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: probe-logs-node${{ matrix.node }}-${{ matrix.arm }}
-          path: probe-logs/
+          name: probe-logs-node${{ matrix.node }}
+          path: |
+            probe-logs/
+            probe-counts.tsv
+            probe-unmatched.txt
           retention-days: 7

--- a/.github/workflows/flake-probe.yaml
+++ b/.github/workflows/flake-probe.yaml
@@ -1,0 +1,187 @@
+# Measures the `test/firestore.test.tsx` flake rate (#776) in CI rather than locally.
+#
+# Every measurement of this flake so far has been on a laptop, where the failure looks
+# like a plain `waitFor` timeout. In CI it comes with a gRPC framing desync
+# (`RESOURCE_EXHAUSTED: Received message larger than max`), which may mean the two are
+# not the same bug. This runs both `@grpc/grpc-js` arms on both Node versions under CI
+# conditions so the comparison is made where the failure actually happens.
+#
+# Manual only. It never runs on a push, a PR or a schedule, so it costs nothing until
+# someone asks for it.
+name: Firestore flake probe
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "Test runs per arm (each is a full emulator start/stop, roughly 25s)"
+        required: false
+        default: "20"
+      node_versions:
+        description: "JSON array of Node majors to probe"
+        required: false
+        default: '["22", "24"]'
+      arms:
+        description: "JSON array of grpc-js arms: baseline, override, or both"
+        required: false
+        default: '["baseline", "override"]'
+
+# Least privilege. This workflow reads the repo and writes nothing back.
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        node: ${{ fromJSON(inputs.node_versions) }}
+        arm: ${{ fromJSON(inputs.arms) }}
+      fail-fast: false
+    name: Probe Node ${{ matrix.node }} / ${{ matrix.arm }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Setup node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node }}
+          check-latest: true
+          cache: 'npm'
+
+      - name: Setup Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Firebase emulator cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/firebase/emulators
+          key: firebase_emulators
+
+      - name: Install deps
+        run: npm ci
+
+      # `npm pkg set` mangles keys containing a slash, so edit package.json directly.
+      # `npm install` (not `npm ci`) is required here because applying an override
+      # necessarily changes the lockfile.
+      - name: Apply the grpc-js override
+        if: ${{ matrix.arm == 'override' }}
+        run: |
+          node -e '
+            const fs = require("fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            pkg.overrides = { ...pkg.overrides, "@grpc/grpc-js": "^1.14.0" };
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+          '
+          npm install --no-audit --no-fund
+
+      - name: Record the resolved grpc-js version
+        run: |
+          RESOLVED="$(node -p "require('@grpc/grpc-js/package.json').version")"
+          echo "resolved_grpc=$RESOLVED" >> "$GITHUB_ENV"
+          echo "Resolved @grpc/grpc-js: $RESOLVED"
+
+      # Inputs and matrix values are passed through `env` rather than interpolated into
+      # the script body, so nothing from the dispatch form can be executed as shell.
+      - name: Run the probe
+        env:
+          ITERATIONS: ${{ inputs.iterations }}
+          ARM: ${{ matrix.arm }}
+          NODE_MAJOR: ${{ matrix.node }}
+        run: |
+          set -uo pipefail
+
+          # Guard against a non-numeric or absurd `iterations` before it reaches the loop.
+          case "$ITERATIONS" in
+            ''|*[!0-9]*) echo "iterations must be a positive integer, got '$ITERATIONS'"; exit 1 ;;
+          esac
+          if [ "$ITERATIONS" -lt 1 ] || [ "$ITERATIONS" -gt 200 ]; then
+            echo "iterations must be between 1 and 200, got '$ITERATIONS'"
+            exit 1
+          fi
+
+          pass=0
+          flake=0
+          infra=0
+          grpc_err=0
+          mkdir -p probe-logs
+
+          for i in $(seq 1 "$ITERATIONS"); do
+            log="probe-logs/run-$i.log"
+
+            # A fresh emulator per iteration, matching how `npm test` runs in CI. Reusing
+            # one emulator across iterations would measure a different thing.
+            set +e
+            npx firebase emulators:exec --only firestore --project=rxfire-525a3 \
+              "npx vitest run firestore" > "$log" 2>&1
+            rc=$?
+            set -e
+
+            if grep -q "RESOURCE_EXHAUSTED: Received message larger than max" "$log"; then
+              grpc_err=$((grpc_err + 1))
+            fi
+
+            if [ "$rc" -eq 0 ]; then
+              pass=$((pass + 1))
+              echo "run $i: PASS"
+            elif grep -q "expected 'loading' to deeply equal 'success'" "$log"; then
+              # The #776 signature specifically, rather than "the job went red".
+              flake=$((flake + 1))
+              echo "run $i: FLAKE (rc=$rc)"
+            else
+              # Emulator start failures and the like. Counted separately because folding
+              # them in previously inflated a local flake-rate estimate by ~50%.
+              infra=$((infra + 1))
+              echo "run $i: INFRA FAILURE (rc=$rc), excluded from the rate"
+              tail -20 "$log"
+            fi
+          done
+
+          counted=$((pass + flake))
+          if [ "$counted" -gt 0 ]; then
+            rate="$(node -e "process.stdout.write(((${flake}/${counted})*100).toFixed(1))")"
+          else
+            rate="n/a"
+          fi
+
+          {
+            echo "### Node ${NODE_MAJOR} / ${ARM} (@grpc/grpc-js ${resolved_grpc})"
+            echo ""
+            echo "| Outcome | Count |"
+            echo "| --- | --- |"
+            echo "| Pass | ${pass} |"
+            echo "| Flake (#776 signature) | ${flake} |"
+            echo "| Infra failure (excluded) | ${infra} |"
+            echo "| Runs showing RESOURCE_EXHAUSTED | ${grpc_err} |"
+            echo ""
+            echo "**Flake rate: ${rate}% of ${counted} counted runs.**"
+            echo ""
+            if [ "$infra" -gt 0 ]; then
+              echo "> ${infra} run(s) failed for reasons other than the #776 assertion and are excluded from the rate."
+              echo ""
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "arm=${ARM} node=${NODE_MAJOR} pass=${pass} flake=${flake} infra=${infra} grpc_err=${grpc_err} rate=${rate}%"
+
+          # The probe reports; it does not fail. A red job here would mean the probe
+          # broke, not that the flake reproduced.
+          if [ "$counted" -eq 0 ]; then
+            echo "Every run failed for infrastructure reasons; the probe measured nothing."
+            exit 1
+          fi
+
+      - name: Upload probe logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: probe-logs-node${{ matrix.node }}-${{ matrix.arm }}
+          path: probe-logs/
+          retention-days: 7


### PR DESCRIPTION
Refs #776. This measures the flake; it does not fix it.

## Why

Every measurement of the #776 flake so far has been on a laptop. Locally the failure is a plain `waitFor` timeout with no gRPC error at all. In CI it arrives alongside a gRPC framing desync:

```
RESOURCE_EXHAUSTED: Received message larger than max (795107700 vs 4194304)
```

A ~795 MB claimed frame against a 4 MB cap means the reader is interpreting payload bytes as a length header. That is a `@grpc/grpc-js`-layer failure, and it does not appear in any local run.

**So the local repro and the CI failure may not be the same bug.** That matters, because the `@grpc/grpc-js` override proposed as the fix was measured only against the local one, at p = 0.12. Merging that override would also mean CI never runs 1.9.16 again, so it is a before-and-after with no control.

This workflow makes the comparison in CI, where the failure actually happens, before anything is changed.

## What it does

Matrixes Node 22 and 24. Within each job it runs **both `@grpc/grpc-js` arms sequentially**, baseline then override, N times per arm (default 30), and writes a table per arm to the job summary: resolved grpc-js version, pass / flake / hang / infra counts, how many runs showed `RESOURCE_EXHAUSTED`, how many flakes showed it too, and the resulting rate.

Design decisions worth reviewing:

- **`workflow_dispatch` only.** It never runs on a push, a PR, a release or a schedule, so it adds nothing to normal CI time.
- **The arms are deliberately NOT a matrix dimension.** The premise of the probe is that the machine matters, so putting the arms on separate runners would reintroduce the variable being measured. They run back to back on one runner instead, which costs a longer job. Arm order is forced baseline-then-override, because applying the override mutates `node_modules` for everything after it.
- **A fresh emulator per iteration**, matching how `npm test` runs in CI. Reusing one emulator across iterations would measure something else.
- **Failures are classified, not counted.** Only the #776 assertion signature counts toward the rate. Emulator start failures are reported separately, because folding them in is exactly what inflated the earlier local estimate by roughly 50% and made 30 runs look adequately powered when they were not.
- **Hangs get their own bucket.** A test timeout produces no assertion line, so without this it would land in `infra` and drop out of the rate entirely. #776 reports a 120s hang.
- **Unrecognized failures are surfaced, not swallowed.** The flake match is a literal vitest assertion string, so a reword would quietly turn every real flake into an infra failure. Anything unmatched has its assertion line collected and shown as a warning in the summary.
- **It reports rather than fails.** A red job here means the probe broke, not that the flake reproduced. It exits non-zero only if every run failed for infrastructure reasons, meaning it measured nothing.
- **The summary renders in an `always()` step** from counts persisted per arm, so a job killed by `timeout-minutes` still reports the arms that finished instead of losing every count.
- **`RESOURCE_EXHAUSTED` is counted per arm, and its overlap with the flake count is counted too.** Two independent totals cannot say whether the gRPC desync and the #776 assertion co-occur, which is the question the probe exists for.
- Inputs reach the script through `env` rather than being interpolated into the shell, and both `iterations` and `arms` are validated before they reach the loop.

⚠️ **This probes one emulator and one test file. CI runs five emulators and the whole suite in parallel.** `RESOURCE_EXHAUSTED` has never appeared in a firestore-only run, so this configuration may reproduce the local failure while never reaching the CI one. Every job summary repeats this, because a clean table here is not a verdict on CI.

## Verification

⚠️ **This workflow cannot be exercised from this PR.** GitHub only offers `workflow_dispatch` for workflows present on the default branch, so it is unrunnable until this merges. Per the repo's own lesson about treating jobs authored on a branch as unrun, it was verified out of band instead:

- **The classifier was dry-run against synthetic logs** covering pass, flake, flake-with-gRPC-error, hang, infra-failure and a *reworded* assertion. It returned the expected counts, excluded hangs and infra failures from the rate, and routed the reworded assertion to the unmatched warning rather than counting it. This is the part most worth getting right, since a probe that miscounts is worse than no probe.
- **The summary was rendered from a partial counts file**, which is the path a job killed by `timeout-minutes` takes.
- **The `arms` input rejects** empty, unknown and non-JSON values, and normalizes to baseline-first regardless of the order given.
- **zizmor 1.25.2** reports no findings beyond the `cache-poisoning` rule CI suppresses, which is the severity set the gate reads.
- YAML parses; the `package.json` override edit produces the right key (`npm pkg set` mangles keys containing a slash, hence the `node -e`); `npx firebase` resolves through `firebase-tools`.

**The first real run is therefore the first proof it works.** If it misbehaves, the fix is another PR, not a rollback of anything consumers see.

## Known confound: narrower than first stated

**Corrected after review.** This section originally warned that the repo-wide override moves `@grpc/grpc-js` for `firebase-tools` and `google-gax` as well as the Firestore client, so the arms differed by more than the library under test. A lockfile diff of the two arms shows that is not the case: **exactly one version moves, `@grpc/grpc-js` 1.9.16 to 1.14.4.** `google-gax` was already on 1.14.4, so its nested copy simply dedupes into the hoisted one. Nothing else budges.

So the arms differ by the Firestore client's grpc-js and nothing else, which is a cleaner comparison than the original caveat implied. Credit to @armando-navarro for diffing it rather than taking the caveat at face value.

## What this changes for anyone else

Nothing. One new file, no existing workflow touched, no runtime or packaging change, and no effect on normal CI.


