### PR TITLE
docs(example): drop the concurrent mode framing from the demo entry

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -2,8 +2,12 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 /**
- * This demo renders without Suspense. To see the Suspense version instead, uncomment the
- * import below and the render block at the bottom of this file.
+ * This demo renders without Suspense. The Suspense version is the commented-out import
+ * below plus the render block at the bottom of this file.
+ *
+ * That path does not run as checked in: it needs react and react-dom on 18 or later, which
+ * this example is not yet on, and the `ReactDOM.render` call below has to be replaced
+ * rather than left alongside it. See #781 for the details.
  *
  * Suspense is off by default in ReactFire and is opted into with the `suspense` prop on
  * `FirebaseAppProvider`. See the Suspense section of the README.

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -2,13 +2,12 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 /**
- * Use this instead of NonConcurrentModeApp to see a ReactFire demo with Suspense/Concurrent mode enabled
+ * This demo renders without Suspense. To see the Suspense version instead, uncomment the
+ * import below and the render block at the bottom of this file.
  *
- * You'll need to use an experimental build of React to use Concurrent mode
- * https://reactjs.org/docs/concurrent-mode-adoption.html#installation
+ * Suspense is off by default in ReactFire and is opted into with the `suspense` prop on
+ * `FirebaseAppProvider`. See the Suspense section of the README.
  */
-// import {} from 'react/experimental'  // make TS aware of experimental features
-// import {} from 'react-dom/experimental' // make TS aware of experimental features
 // import { App as ConcurrentModeApp } from './withSuspense/App';
 import { App as NonConcurrentModeApp } from './withoutSuspense/App';
 import './index.css';
@@ -37,7 +36,7 @@ ReactDOM.render(
 );
 
 /**
- * FOR CONCURRENT MODE
+ * FOR THE SUSPENSE VERSION
  */
 // ReactDOM.createRoot(rootElement).render(
 //   <FirebaseAppProvider firebaseConfig={firebaseConfig} suspense={true}>


### PR DESCRIPTION
Follow-up to #778, which removed this same obsolete premise from the README but left this copy of it. Refs #756.

## What was wrong

`example/index.tsx` told readers:

> You'll need to use an experimental build of React to use Concurrent mode
> https://reactjs.org/docs/concurrent-mode-adoption.html#installation

React 18 shipped in 2022 and concurrent mode was abandoned as a concept rather than stabilised, so that instruction cannot be followed and the link is a dead page. The two commented-out `react/experimental` and `react-dom/experimental` imports existed only to serve that premise, so they go with it.

**This removes the last `reactjs.org` reference in the repository.** #778's description originally claimed to have done that, which was wrong, and Armando caught it. This is the correction.

## Scope

**Comments only.** No active code changed, so the demo behaves identically. 5 lines added, 6 removed.

I deliberately did not fix two related things I found while in here, because both are more than a comment edit. Pricing them rather than leaving them vague:

**1. The example uses the legacy render API, and the commented-out "concurrent" path uses the modern one.** The active code calls `ReactDOM.render`, deprecated in React 18. The commented-out block calls `ReactDOM.createRoot`, which is now simply the standard API and not experimental at all. So the file currently has it backwards: the path labelled experimental is the current one. Fixing this is a real change to the demo, roughly a 5 line diff plus actually running the example to confirm it still works, and it deserves its own PR rather than riding along in a comment cleanup.

**2. The identifiers are still named for concurrent mode.** `NonConcurrentModeApp` and `ConcurrentModeApp` are local import aliases in this one file, so renaming them to something like `AppWithoutSuspense` and `AppWithSuspense` is about 3 lines and affects nothing outside it. I left them because this PR touches no active code and I would rather that stay true. Worth doing alongside item 1.

Neither is urgent. Both are cheap. Flagging them so they are a decision rather than something that quietly rots for another four years.

## Not addressed

Whether the `withSuspense` demo path should be revived, rewritten or deleted is a genuine question and not a docs edit. It has been commented out long enough that nobody knows if it runs. That belongs with the V5 Suspense work, since the suspend path moves to `use()` there anyway.
