### PR TITLE
test(firestore): wait out the emulator's Listen-stream backoff

### DIFF
--- a/test/firestore.test.tsx
+++ b/test/firestore.test.tsx
@@ -30,6 +30,22 @@ describe('Firestore', () => {
     </FirebaseAppProvider>
   );
 
+  // The Firestore emulator intermittently corrupts a Listen frame
+  // (firebase/firebase-tools#8654, unresolved upstream). The SDK reads it as
+  // RESOURCE_EXHAUSTED and parks the stream on a 60s maximum backoff, but a
+  // reconnect is not what rescues these tests: the same failure drives the
+  // client to OnlineState.Offline after ONLINE_STATE_TIMEOUT_MS (10s), and an
+  // offline client raises the pending snapshot from the local cache, empty
+  // cache included. These two tests assert that a document is absent, which is
+  // what the empty cache reports, so they go green at ~10s with no server
+  // involved. They are the only two whose first snapshot cannot be served from
+  // local data. The budget is a ceiling, not a delay, since `waitFor` polls.
+  // Remove when #8654 is fixed upstream. See #776.
+  const WAIT_FOR_OFFLINE_FALLBACK = 120_000;
+  // vitest enforces its own per-test ceiling, so each test below gets more than
+  // the sum of the budgets under it; otherwise only the first `waitFor` could
+  // ever spend what it is given.
+
   afterEach(async () => {
     cleanup();
 
@@ -108,11 +124,11 @@ describe('Firestore', () => {
 
       const { result } = renderHook(() => useFirestoreDocData<any>(ref, { idField: 'id' }), { wrapper: Provider });
 
-      await waitFor(() => expect(result.current.status).toEqual('success'));
+      await waitFor(() => expect(result.current.status).toEqual('success'), { timeout: WAIT_FOR_OFFLINE_FALLBACK });
 
       expect(result.current.status).toEqual('success');
       expect(result.current.data).toBeUndefined();
-    });
+    }, 150_000);
 
     it('goes back into a loading state if you swap the query', async () => {
       const mockData = { a: 'hello' };
@@ -177,17 +193,20 @@ describe('Firestore', () => {
       const { result: subscribeResult } = renderHook(() => useFirestoreDoc(ref), { wrapper: Provider });
       const { result: onceResult } = renderHook(() => useFirestoreDocOnce(ref), { wrapper: Provider });
 
-      await waitFor(() => expect(subscribeResult.current.status).toEqual('success'));
-      await waitFor(() => expect(onceResult.current.status).toEqual('success'));
+      await waitFor(() => expect(subscribeResult.current.status).toEqual('success'), { timeout: WAIT_FOR_OFFLINE_FALLBACK });
+      await waitFor(() => expect(onceResult.current.status).toEqual('success'), { timeout: WAIT_FOR_OFFLINE_FALLBACK });
 
       expect(onceResult.current.data.exists()).toEqual(false);
 
       await act(() => setDoc(ref, { a: 'test' }));
 
+      // No budget: this waits on the client's own write, which is raised from
+      // the local cache before the acknowledgement returns (measured at 8ms
+      // with the client offline).
       await waitFor(() => expect(subscribeResult.current.data.exists()).toEqual(true));
 
       expect(onceResult.current.data.exists()).toEqual(false);
-    });
+    }, 270_000);
   });
 
   describe('useFirestoreDocDataOnce', () => {


### PR DESCRIPTION
## Why

`test/firestore.test.tsx` flakes at roughly 18% per run (11 of 60 iterations, measured 2026-08-11). The Firestore emulator intermittently corrupts a Listen frame, grpc-js reads four body bytes as a length prefix, and the SDK answers the resulting `RESOURCE_EXHAUSTED` by parking the stream on a 60 second maximum backoff.

This is an unresolved upstream emulator bug, [firebase-tools#8654](https://github.com/firebase/firebase-tools/issues/8654). Nothing to pin, so this survives it rather than preventing it.

## What actually rescues the tests

Not a reconnect. The same failure sends the client to `OnlineState.Offline` after `ONLINE_STATE_TIMEOUT_MS` (10s), and an offline client raises the pending snapshot from the local cache, empty cache included. Two tests assert that a document is absent, which is exactly what the empty cache reports, so they reach success about ten seconds after the failure with no server involved. They are the only two in the file whose first snapshot cannot be served from local data.

Those two currently abandon the wait after one second, before the fallback can fire, and vitest would kill them at five seconds regardless. Both ceilings have to move or neither does anything.

## What changed

Three `waitFor` calls get a 120s budget, and the two tests holding them get vitest timeouts of 150s and 270s, each clearing the sum of the budgets beneath it. 120s is far above the ~10s the fallback needs, deliberately, because a ceiling is not a delay.

`waitFor` polls at 50ms, so the larger ceiling costs nothing on a healthy run. Per-test durations, healthy samples only:

| Test | With | Without |
| --- | --- | --- |
| `returns undefined if document does not exist` | 80-95ms (n=9) | 82-136ms (n=3) |
| `works when the document does not exist...` | 90-140ms (n=11) | 101-120ms (n=3) |

The bands overlap; the wider upper tail on the larger sample is sampling, not cost.

The third wait in `useFirestoreDocOnce` keeps the 1000ms default deliberately. It waits on the client's own write, which is raised from the local cache before the acknowledgement returns, so the offline fallback has no bearing on it. Measured with the client offline via `disableNetwork`: the write reaches an attached listener in 8ms, `fromCache=true`, against a control that fails at 1000ms when no write is issued.

## Verification

**The desync reproduced locally twice during this work, having never been seen off CI before, and was rescued both times.** One has a full log, carrying `RESOURCE_EXHAUSTED: Received message larger than max (4110323459 vs 4194304)` and `Using maximum backoff delay`, with `returns undefined if document does not exist` taking **9878ms and passing** where it normally runs 80-95ms. The other is a 9872ms sample from a batch that discarded output. CI showed the same rescue on this branch at 9795ms ([details](https://github.com/FirebaseExtended/reactfire/pull/791#issuecomment-5272203466)).

All three observations are with the fix in place. That the old ceilings would have killed a 9878ms wait follows from testing-library's 1000ms default and vitest's 5000ms, not from an observed failure.

Also verified: a simulated 65s stall survives the new budget and fails under the default; the per-test ceilings apply, confirmed by shortening one until it failed; both typechecks clean; firestore suite green against the emulator.

**Signal for closing #776:** desyncs keep appearing in logs while flakes stop. A rescued run reaches its assertion from an empty cache rather than from the server, so a zero flake count alone is not comparable to the 18.3% baseline. The probe records `saw_grpc` per iteration, and a rescued desync shows up as `outcome=pass` with `saw_grpc=1`.

## Cost

A genuine regression in those two tests now takes up to 120s to surface instead of 1s, confined to the two tests this bug can kill.

Refs #776
